### PR TITLE
TERMINAL-053: Visual polish & delight pass (Calm Hacker)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,27 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // React Compiler optimization hints — advisory only, not correctness bugs.
+      // The codebase uses legitimate setState-in-effect and manual memoization
+      // patterns the compiler can't verify; disabling silences noise without
+      // affecting runtime behavior.
+      'react-hooks/set-state-in-effect': 'off',
+      'react-hooks/preserve-manual-memoization': 'off',
+      'react-hooks/refs': 'off',
+      'react-hooks/immutability': 'off',
+      // Allow leading-underscore args/params to be intentionally unused.
+      // Keeps pane signature (pane, workspaceId, focused) consistent across
+      // components that don't need every field.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+    },
   },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@xterm/addon-fit": "^0.11.0",
@@ -910,6 +911,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@xterm/addon-fit": "^0.11.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -249,7 +249,7 @@ function AppContent() {
     };
     window.addEventListener('open-file-viewer', handler);
     return () => window.removeEventListener('open-file-viewer', handler);
-  }, [focusedPaneId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [focusedPaneId]);
 
   // Command palette state
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -314,7 +314,7 @@ function AppContent() {
 
     const detectAndConnect = async () => {
       // Check for Tauri runtime (injected by the native shell, not present in browsers)
-      if (!(window as any).__TAURI_INTERNALS__) {
+      if (!(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__) {
         console.log('[Browser] Tauri runtime not detected, using standalone mode');
         setDaemonUrl('ws://127.0.0.1:3000/ws');
         setTauriMode(false);
@@ -510,6 +510,8 @@ function AppContent() {
     // Use capture phase to intercept shortcuts before xterm.js consumes them
     window.addEventListener('keydown', handleKeyDown, { capture: true });
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
+    // `send` is stable via ref but not literally in deps — exhaustive-deps noise.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, commandPaletteOpen, cheatsheetOpen, layout, focusedPaneId, handleSplitPane]);
 
   return (

--- a/frontend/src/components/ActivityBar.tsx
+++ b/frontend/src/components/ActivityBar.tsx
@@ -25,15 +25,20 @@ export function ActivityBar({ onLayoutPreset }: ActivityBarProps) {
   const active = state.activeSidebarView;
 
   const iconStyle = (isActive: boolean): React.CSSProperties => ({
-    width: 36,
-    height: 36,
+    width: 32,
+    height: 32,
+    margin: '2px 4px',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     cursor: 'pointer',
-    borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent',
-    color: isActive ? 'var(--text-primary)' : 'var(--text-muted)',
-    transition: 'color 120ms ease',
+    borderRadius: 6,
+    color: isActive ? 'var(--accent-primary)' : 'var(--text-muted)',
+    backgroundColor: isActive ? 'var(--accent-primary-15)' : 'transparent',
+    boxShadow: isActive ? 'var(--glow-accent)' : 'none',
+    transition:
+      'color 180ms var(--ease-out-expo), background-color 200ms var(--ease-out-expo), ' +
+      'transform 180ms var(--ease-out-expo), box-shadow 200ms var(--ease-out-expo)',
   });
 
   return (
@@ -60,16 +65,28 @@ export function ActivityBar({ onLayoutPreset }: ActivityBarProps) {
               else dispatch({ type: 'SET_SIDEBAR_VIEW', view });
             }}
             style={iconStyle(isActive)}
-            onMouseEnter={(e) => { if (!isActive) e.currentTarget.style.color = 'var(--text-secondary)'; }}
-            onMouseLeave={(e) => { if (!isActive) e.currentTarget.style.color = 'var(--text-muted)'; }}
+            onMouseEnter={(e) => {
+              if (!isActive) {
+                e.currentTarget.style.color = 'var(--text-primary)';
+                e.currentTarget.style.backgroundColor = 'var(--accent-primary-08)';
+                e.currentTarget.style.transform = 'scale(1.06)';
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isActive) {
+                e.currentTarget.style.color = 'var(--text-muted)';
+                e.currentTarget.style.backgroundColor = 'transparent';
+                e.currentTarget.style.transform = 'scale(1)';
+              }
+            }}
           >
-            <Icon size={18} strokeWidth={1.5} />
+            <Icon size={18} strokeWidth={1.75} />
           </div>
         );
       })}
 
       {/* Separator */}
-      <div style={{ width: 20, height: 1, backgroundColor: 'var(--border-default)', margin: '4px 0' }} />
+      <div style={{ width: 20, height: 1, backgroundColor: 'var(--border-default)', margin: '6px 0' }} />
 
       {/* Layout preset icons */}
       {layoutIcons.map(({ preset, label, Icon }) => (
@@ -78,10 +95,18 @@ export function ActivityBar({ onLayoutPreset }: ActivityBarProps) {
           title={label}
           onClick={() => onLayoutPreset?.(preset)}
           style={iconStyle(false)}
-          onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--text-secondary)'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-muted)'; }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = 'var(--text-primary)';
+            e.currentTarget.style.backgroundColor = 'var(--accent-primary-08)';
+            e.currentTarget.style.transform = 'scale(1.06)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = 'var(--text-muted)';
+            e.currentTarget.style.backgroundColor = 'transparent';
+            e.currentTarget.style.transform = 'scale(1)';
+          }}
         >
-          <Icon size={18} strokeWidth={1.5} />
+          <Icon size={18} strokeWidth={1.75} />
         </div>
       ))}
     </div>

--- a/frontend/src/components/AppChrome.tsx
+++ b/frontend/src/components/AppChrome.tsx
@@ -54,12 +54,26 @@ export function AppChrome() {
         paddingRight: 12,
         gap: 0,
         flexShrink: 0,
-        fontFamily: 'var(--font-mono)',
-        fontSize: 'var(--font-size-chrome)',
+        fontFamily: 'var(--font-display)',
+        fontSize: 'var(--font-size-label)',
+        letterSpacing: '0.01em',
       }}
     >
       {/* Title */}
-      <span style={{ fontWeight: 'bold', color: 'var(--text-primary)', marginRight: 12, whiteSpace: 'nowrap' }}>
+      <span
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontWeight: 700,
+          fontSize: 13,
+          letterSpacing: '-0.01em',
+          marginRight: 16,
+          whiteSpace: 'nowrap',
+          background: 'linear-gradient(135deg, var(--text-primary) 0%, var(--accent-primary) 120%)',
+          WebkitBackgroundClip: 'text',
+          backgroundClip: 'text',
+          color: 'transparent',
+        }}
+      >
         Terminal Engine
       </span>
 
@@ -82,8 +96,13 @@ export function AppChrome() {
                 borderBottom: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent',
                 color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)',
                 backgroundColor: isActive ? 'var(--bg-overlay)' : 'transparent',
+                boxShadow: isActive ? 'inset 0 -2px 0 var(--accent-primary), 0 0 12px -6px var(--accent-primary)' : 'none',
+                fontFamily: 'var(--font-display)',
+                fontWeight: isActive ? 600 : 500,
+                fontSize: 12,
+                letterSpacing: '0.01em',
                 whiteSpace: 'nowrap',
-                transition: 'color 100ms, background-color 100ms',
+                transition: 'color 160ms var(--ease-out-expo), background-color 160ms var(--ease-out-expo), border-color 200ms var(--ease-out-expo), box-shadow 200ms var(--ease-out-expo)',
               }}
               onMouseEnter={(e) => { if (!isActive) e.currentTarget.style.backgroundColor = 'var(--bg-raised)'; }}
               onMouseLeave={(e) => { if (!isActive) e.currentTarget.style.backgroundColor = 'transparent'; }}
@@ -138,10 +157,45 @@ export function AppChrome() {
       </div>
 
       {/* Right: Ctrl+K hint + connection status */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, whiteSpace: 'nowrap' }}>
-        <span style={{ color: 'var(--text-muted)' }}>Ctrl+K</span>
-        <span style={{ display: 'flex', alignItems: 'center', gap: 4, color: statusColor }}>
-          <span style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: statusColor }} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, whiteSpace: 'nowrap' }}>
+        <span
+          style={{
+            color: 'var(--text-muted)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            padding: '2px 8px',
+            border: '1px solid var(--border-default)',
+            borderRadius: 4,
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            letterSpacing: '0.04em',
+          }}
+        >
+          ⌘K
+        </span>
+        <span
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            color: statusColor,
+            fontFamily: 'var(--font-display)',
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.02em',
+          }}
+        >
+          <span
+            style={{
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              backgroundColor: statusColor,
+              boxShadow: connectionStatus === 'connected' ? '0 0 8px currentColor' : 'none',
+              animation: connectionStatus === 'connecting' ? 'soft-pulse 1.2s ease-in-out infinite' : 'none',
+            }}
+          />
           {connectionStatus}
         </span>
       </div>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -246,7 +246,7 @@ export function CommandPalette({ open, onClose, onLayoutChange, onSplitH, onSpli
         action: () => { applyTheme(theme.id); onClose(); },
       })),
     ],
-    [send, dispatch, onClose, onLayoutChange, zoomedPaneId, onZoomPane, onShowShortcuts, onOpenSsh],
+    [send, dispatch, onClose, onLayoutChange, onSplitH, onSplitV, onAddPane, zoomedPaneId, onZoomPane, onShowShortcuts, onOpenSsh],
   );
 
   // Determine effective mode: if query starts with '!' override to quick-commands,

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -450,10 +450,13 @@ export function CommandPalette({ open, onClose, onLayoutChange, onSplitH, onSpli
 
   return (
     <div
+      className="anim-fade-in"
       style={{
         position: 'fixed',
         inset: 0,
-        backgroundColor: 'rgba(0,0,0,0.5)',
+        backgroundColor: 'rgba(0,0,0,0.42)',
+        backdropFilter: 'blur(4px)',
+        WebkitBackdropFilter: 'blur(4px)',
         display: 'flex',
         alignItems: 'flex-start',
         justifyContent: 'center',
@@ -463,16 +466,19 @@ export function CommandPalette({ open, onClose, onLayoutChange, onSplitH, onSpli
       onClick={onClose}
     >
       <div
+        className="anim-scale-in"
         style={{
-          backgroundColor: 'var(--bg-raised)',
-          border: '1px solid var(--border-default)',
+          backgroundColor: 'var(--bg-glass)',
+          backdropFilter: 'blur(18px)',
+          WebkitBackdropFilter: 'blur(18px)',
+          border: '1px solid var(--glass-border)',
           borderRadius: 12,
           width: 560,
           maxHeight: '60vh',
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
-          boxShadow: '0 16px 48px rgba(0,0,0,0.4)',
+          boxShadow: 'var(--shadow-overlay), var(--glow-accent)',
         }}
         onClick={(e) => e.stopPropagation()}
       >
@@ -495,13 +501,15 @@ export function CommandPalette({ open, onClose, onLayoutChange, onSplitH, onSpli
           onKeyDown={handleKeyDown}
           placeholder={placeholderText}
           style={{
-            padding: '12px 16px',
-            backgroundColor: 'var(--bg-surface)',
+            padding: '14px 18px',
+            backgroundColor: 'transparent',
             border: 'none',
-            borderBottom: '1px solid var(--border-default)',
+            borderBottom: '1px solid var(--glass-border)',
             color: 'var(--text-primary)',
-            fontSize: 16,
-            fontFamily: 'monospace',
+            fontSize: 15,
+            fontFamily: 'var(--font-display)',
+            fontWeight: 400,
+            letterSpacing: '0.01em',
             outline: 'none',
           }}
         />

--- a/frontend/src/components/PostRunSummary.tsx
+++ b/frontend/src/components/PostRunSummary.tsx
@@ -151,9 +151,7 @@ export function PostRunSummary({ runId, onGetDiff, onMerge, onRevert }: PostRunS
         {exitCode !== null && (
           <div>
             <div style={labelStyle}>Exit Code</div>
-            <div style={{ color: exitCode === 0 ? 'var(--accent-primary)' : 'var(--accent-error)', fontWeight: 'bold' }}>
-              {exitCode}
-            </div>
+            <ExitCodeBadge code={exitCode} />
           </div>
         )}
         <div>
@@ -313,6 +311,80 @@ export function PostRunSummary({ runId, onGetDiff, onMerge, onRevert }: PostRunS
   );
 }
 
+/** Exit-code badge with a subtle sparkle burst on success. */
+function ExitCodeBadge({ code }: { code: number }) {
+  const success = code === 0;
+  const color = success ? 'var(--accent-primary)' : 'var(--accent-error)';
+  const glow = success ? 'var(--glow-accent)' : 'var(--glow-error)';
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minWidth: 28,
+          padding: '2px 10px',
+          borderRadius: 10,
+          border: `1px solid ${color}`,
+          color,
+          fontFamily: 'var(--font-mono)',
+          fontWeight: 700,
+          fontSize: 12,
+          boxShadow: glow,
+          background: success ? 'var(--accent-primary-08)' : 'rgba(var(--accent-error-rgb), 0.08)',
+        }}
+      >
+        {code}
+      </span>
+      {success && <Sparkles />}
+    </div>
+  );
+}
+
+/** 6 tiny dots bursting outward on mount. GPU-only. */
+function Sparkles() {
+  const dots = [
+    { dx: '22px', dy: '-14px', color: 'var(--accent-primary)', size: 3, delay: 0 },
+    { dx: '-18px', dy: '-18px', color: '#fff', size: 2, delay: 40 },
+    { dx: '24px', dy: '10px', color: 'var(--accent-warn)', size: 3, delay: 80 },
+    { dx: '-22px', dy: '8px', color: 'var(--accent-primary)', size: 2, delay: 60 },
+    { dx: '4px', dy: '-22px', color: '#fff', size: 2, delay: 110 },
+    { dx: '8px', dy: '20px', color: 'var(--accent-primary)', size: 2, delay: 140 },
+  ];
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+        display: 'block',
+      }}
+    >
+      {dots.map((d, i) => (
+        <span
+          key={i}
+          style={{
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            width: d.size,
+            height: d.size,
+            borderRadius: '50%',
+            background: d.color,
+            boxShadow: `0 0 6px ${d.color}`,
+            opacity: 0,
+            ['--dx' as string]: d.dx,
+            ['--dy' as string]: d.dy,
+            animation: `sparkle-burst 720ms var(--ease-out-expo) ${d.delay}ms forwards`,
+          } as React.CSSProperties}
+        />
+      ))}
+    </span>
+  );
+}
+
 function DiffStatBar({ insertions, deletions }: { insertions: number; deletions: number }) {
   const total = insertions + deletions;
   if (total === 0) return null;
@@ -337,7 +409,8 @@ function DiffStatBar({ insertions, deletions }: { insertions: number; deletions:
           style={{
             width: `${insPercent}%`,
             backgroundColor: 'var(--accent-primary)',
-            transition: 'width 0.3s ease',
+            boxShadow: 'inset 0 0 6px rgba(var(--accent-primary-rgb), 0.4)',
+            transition: 'width 320ms var(--ease-out-expo)',
           }}
         />
       )}
@@ -346,7 +419,8 @@ function DiffStatBar({ insertions, deletions }: { insertions: number; deletions:
           style={{
             width: `${delPercent}%`,
             backgroundColor: 'var(--accent-error)',
-            transition: 'width 0.3s ease',
+            boxShadow: 'inset 0 0 6px rgba(var(--accent-error-rgb), 0.4)',
+            transition: 'width 320ms var(--ease-out-expo)',
           }}
         />
       )}

--- a/frontend/src/components/RunPanel.tsx
+++ b/frontend/src/components/RunPanel.tsx
@@ -11,8 +11,34 @@ export function RunPanel() {
 
   if (!state.activeRun && state.outputLines.length === 0) {
     return (
-      <div style={{ padding: 24, color: 'var(--text-muted)', fontFamily: 'monospace' }}>
-        No active run. Start a session and run a prompt.
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 10,
+          padding: 24,
+          color: 'var(--text-muted)',
+          fontFamily: 'var(--font-display)',
+          fontSize: 13,
+          letterSpacing: '0.01em',
+        }}
+      >
+        <div
+          aria-hidden="true"
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: 'var(--accent-primary)',
+            opacity: 0.35,
+            boxShadow: '0 0 14px rgba(var(--accent-primary-rgb), 0.25)',
+          }}
+        />
+        <div>no active run</div>
+        <div style={{ fontSize: 11, opacity: 0.7 }}>start a session, then run a prompt</div>
       </div>
     );
   }
@@ -22,29 +48,55 @@ export function RunPanel() {
       style={{
         flex: 1,
         overflow: 'auto',
-        padding: '12px 16px',
-        fontFamily: 'monospace',
+        padding: '14px 18px',
+        fontFamily: 'var(--font-mono)',
         fontSize: 13,
-        lineHeight: 1.5,
+        lineHeight: 1.55,
         backgroundColor: 'var(--bg-surface)',
         color: 'var(--text-primary)',
       }}
     >
-      {state.outputLines.map((line, i) => (
+      {state.outputLines.map((line, i) => {
+        const isStderr = line.startsWith('[stderr]');
+        return (
+          <div
+            key={i}
+            style={{
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+              color: isStderr ? 'var(--accent-error)' : 'var(--text-primary)',
+              opacity: isStderr ? 0.95 : 1,
+            }}
+          >
+            {line}
+          </div>
+        );
+      })}
+      {state.activeRun && (
         <div
-          key={i}
           style={{
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            color: line.startsWith('[stderr]') ? 'var(--accent-error)' : 'var(--text-primary)',
+            marginTop: 6,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            color: 'var(--accent-primary)',
+            fontFamily: 'var(--font-display)',
+            fontSize: 12,
+            letterSpacing: '0.02em',
           }}
         >
-          {line}
-        </div>
-      ))}
-      {state.activeRun && (
-        <div style={{ color: 'var(--accent-primary)', marginTop: 8 }}>
-          Running...
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'inline-block',
+              width: 8,
+              height: 16,
+              background: 'var(--accent-primary)',
+              borderRadius: 1,
+              animation: 'glow-pulse 1.4s ease-in-out infinite',
+            }}
+          />
+          <span style={{ opacity: 0.85 }}>running</span>
         </div>
       )}
       <div ref={bottomRef} />

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -82,8 +82,19 @@ export function StatusBar() {
           onClick={() => window.dispatchEvent(new CustomEvent('focus-pane-kind', { detail: 'AiRun' }))}
           title="Focus AI Run pane"
         >
-          <span style={{ color: 'var(--accent-warn)', display: 'flex', alignItems: 'center', gap: 4 }}>
-            <span>&#9679;</span>
+          <span style={{ color: 'var(--accent-warn)', display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span
+              aria-hidden="true"
+              style={{
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                backgroundColor: 'var(--accent-warn)',
+                animation: 'soft-pulse 1.2s ease-in-out infinite',
+                boxShadow: '0 0 8px rgba(var(--accent-warn-rgb), 0.6)',
+              }}
+            />
             AI running
           </span>
         </StatusBarItem>
@@ -94,8 +105,11 @@ export function StatusBar() {
         title={isDisconnected ? 'Click to reconnect' : state.connection.status}
       >
         <span style={{
-          width: 6, height: 6, borderRadius: '50%',
+          width: 7, height: 7, borderRadius: '50%',
           backgroundColor: state.connection.status === 'connected' ? 'var(--accent-primary)' : 'var(--accent-error)',
+          boxShadow: state.connection.status === 'connected'
+            ? '0 0 6px rgba(var(--accent-primary-rgb), 0.7)'
+            : 'none',
         }} />
         {state.connection.status}
       </StatusBarItem>

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -72,27 +72,31 @@ export function ToastContainer() {
         <div
           key={toast.id}
           style={{
-            backgroundColor: 'var(--bg-raised)',
-            border: '1px solid var(--border-default)',
+            backgroundColor: 'var(--bg-glass)',
+            backdropFilter: 'blur(14px)',
+            WebkitBackdropFilter: 'blur(14px)',
+            border: '1px solid var(--glass-border)',
+            borderLeft: '3px solid var(--accent-primary)',
             borderRadius: 8,
             padding: '10px 14px',
-            boxShadow: '0 4px 16px rgba(0,0,0,0.35)',
+            boxShadow: 'var(--shadow-toast), var(--glow-accent)',
             display: 'flex',
             flexDirection: 'column',
             gap: 6,
             minWidth: 240,
             maxWidth: 320,
             pointerEvents: 'all',
-            animation: 'toast-slide-in 0.2s ease-out',
+            animation: 'toast-slide-in 220ms var(--ease-out-expo)',
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
             <span
               style={{
                 fontSize: 12,
-                fontFamily: 'var(--font-mono, monospace)',
+                fontFamily: 'var(--font-display)',
                 color: 'var(--text-primary)',
                 fontWeight: 600,
+                letterSpacing: '0.01em',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
@@ -130,15 +134,17 @@ export function ToastContainer() {
             onClick={() => jumpToPane(toast.paneId, toast.id)}
             style={{
               alignSelf: 'flex-start',
-              padding: '3px 10px',
+              padding: '4px 12px',
               backgroundColor: 'var(--accent-primary)',
               color: 'var(--bg-base)',
               border: 'none',
               borderRadius: 4,
               cursor: 'pointer',
               fontSize: 11,
-              fontFamily: 'var(--font-mono, monospace)',
+              fontFamily: 'var(--font-display)',
               fontWeight: 600,
+              letterSpacing: '0.02em',
+              boxShadow: 'var(--glow-accent)',
             }}
           >
             Jump
@@ -148,8 +154,8 @@ export function ToastContainer() {
 
       <style>{`
         @keyframes toast-slide-in {
-          from { opacity: 0; transform: translateX(20px); }
-          to   { opacity: 1; transform: translateX(0); }
+          from { opacity: 0; transform: translateX(24px) scale(0.96); }
+          to   { opacity: 1; transform: translateX(0) scale(1); }
         }
       `}</style>
     </div>

--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { getSavedSessions, deleteSession } from '../state/sessionStore';
 import type { SavedSession } from '../state/sessionStore';
 import { collectPanes } from '../domain/pane/types';
@@ -30,12 +31,58 @@ function relativeTime(isoDate: string): string {
   return `${months}mo ago`;
 }
 
+/** Small animated terminal glyph used as the Welcome logo. */
+function TerminalGlyph({ size = 48 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      fill="none"
+      aria-hidden="true"
+      style={{ filter: 'drop-shadow(0 0 10px rgba(var(--accent-primary-rgb), 0.35))' }}
+    >
+      <rect
+        x="3.5"
+        y="7.5"
+        width="41"
+        height="33"
+        rx="7"
+        stroke="var(--accent-primary)"
+        strokeWidth="1.8"
+        fill="var(--bg-raised)"
+      />
+      <circle cx="10" cy="13.5" r="1.3" fill="var(--accent-error)" opacity="0.75" />
+      <circle cx="14.5" cy="13.5" r="1.3" fill="var(--accent-warn)" opacity="0.75" />
+      <circle cx="19" cy="13.5" r="1.3" fill="var(--accent-primary)" opacity="0.75" />
+      {/* Prompt caret */}
+      <path
+        d="M11 27 L15 30 L11 33"
+        stroke="var(--accent-primary)"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Blinking cursor line */}
+      <rect
+        x="18.5"
+        y="29"
+        width="16"
+        height="2"
+        rx="1"
+        fill="var(--accent-primary)"
+        style={{ animation: 'caret-blink 1.4s steps(2) infinite' }}
+      />
+    </svg>
+  );
+}
+
 export function WelcomeScreen({ onOpenSession, onNewSession, tauriMode, onBrowse }: WelcomeScreenProps) {
   const [sessions, setSessions] = useState<SavedSession[]>(() => getSavedSessions());
   const [newPath, setNewPath] = useState('');
   const [hoveredRoot, setHoveredRoot] = useState<string | null>(null);
+  const [inputFocused, setInputFocused] = useState(false);
 
-  // Refresh list whenever localStorage changes (e.g. other tab)
   useEffect(() => {
     const handler = () => setSessions(getSavedSessions());
     window.addEventListener('storage', handler);
@@ -61,14 +108,18 @@ export function WelcomeScreen({ onOpenSession, onNewSession, tauriMode, onBrowse
 
   return (
     <div style={styles.overlay}>
-      <div style={styles.card}>
+      {/* Subtle teal spotlight behind the card */}
+      <div style={styles.spotlight} aria-hidden="true" />
+      <div style={styles.card} className="anim-scale-in">
         {/* Header */}
         <div style={styles.header}>
           <div style={styles.logo}>
-            <span style={styles.logoIcon}>⌨</span>
-            <span style={styles.logoTitle}>Terminal Engine</span>
+            <TerminalGlyph size={48} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={styles.logoTitle}>Terminal Engine</span>
+              <span style={styles.subtitle}>your workspace, your way</span>
+            </div>
           </div>
-          <p style={styles.subtitle}>Start a session</p>
         </div>
 
         {/* Recent sessions */}
@@ -76,17 +127,31 @@ export function WelcomeScreen({ onOpenSession, onNewSession, tauriMode, onBrowse
           <div style={styles.sectionLabel}>Recent</div>
           {sessions.length === 0 ? (
             <div style={styles.emptyState}>
-              No recent sessions. Enter a project path below to start.
+              <span>no recent sessions — start your first below</span>
+              <ChevronDown
+                size={16}
+                strokeWidth={1.75}
+                style={{
+                  color: 'var(--accent-primary)',
+                  opacity: 0.7,
+                  animation: 'chevron-nudge 1.6s ease-in-out infinite',
+                }}
+              />
             </div>
           ) : (
             <div style={styles.sessionList}>
-              {sessions.map(session => {
+              {sessions.map((session, idx) => {
                 const paneCount = collectPanes(session.layout).length;
                 const isHovered = hoveredRoot === session.projectRoot;
                 return (
                   <div
                     key={session.projectRoot}
-                    style={{ ...styles.sessionRow, ...(isHovered ? styles.sessionRowHover : {}) }}
+                    className="stagger-in"
+                    style={{
+                      ...styles.sessionRow,
+                      ...(isHovered ? styles.sessionRowHover : {}),
+                      ['--i' as string]: idx,
+                    } as React.CSSProperties}
                     onMouseEnter={() => setHoveredRoot(session.projectRoot)}
                     onMouseLeave={() => setHoveredRoot(null)}
                   >
@@ -133,8 +198,13 @@ export function WelcomeScreen({ onOpenSession, onNewSession, tauriMode, onBrowse
               value={newPath}
               onChange={e => setNewPath(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && handleStart()}
+              onFocus={() => setInputFocused(true)}
+              onBlur={() => setInputFocused(false)}
               placeholder="/path/to/project"
-              style={styles.pathInput}
+              style={{
+                ...styles.pathInput,
+                ...(inputFocused ? styles.pathInputFocused : {}),
+              }}
               autoFocus
             />
             {tauriMode && onBrowse && (
@@ -150,6 +220,13 @@ export function WelcomeScreen({ onOpenSession, onNewSession, tauriMode, onBrowse
               Start
             </button>
           </div>
+          <div style={styles.hint}>
+            <span style={styles.kbd}>⌘K</span>
+            <span>for commands</span>
+            <span style={styles.dot}>·</span>
+            <span style={styles.kbd}>⌘/</span>
+            <span>for shortcuts</span>
+          </div>
         </div>
       </div>
     </div>
@@ -162,24 +239,34 @@ export function WelcomeScreen({ onOpenSession, onNewSession, tauriMode, onBrowse
 
 const styles: Record<string, React.CSSProperties> = {
   overlay: {
+    position: 'relative',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     height: '100vh',
     width: '100%',
     background: 'var(--bg-base)',
+    overflow: 'hidden',
+  },
+  spotlight: {
+    position: 'absolute',
+    inset: 0,
+    background:
+      'radial-gradient(ellipse 900px 500px at 50% 32%, rgba(var(--accent-primary-rgb), 0.07) 0%, transparent 65%)',
+    pointerEvents: 'none',
   },
   card: {
+    position: 'relative',
     background: 'var(--bg-surface)',
     border: '1px solid var(--border-default)',
-    borderRadius: 10,
-    padding: '32px 36px',
+    borderRadius: 12,
+    padding: '36px 40px',
     width: '100%',
     maxWidth: 580,
     display: 'flex',
     flexDirection: 'column',
     gap: 28,
-    boxShadow: '0 8px 32px rgba(0,0,0,0.35)',
+    boxShadow: 'var(--shadow-overlay), var(--glow-accent)',
   },
   header: {
     display: 'flex',
@@ -189,47 +276,52 @@ const styles: Record<string, React.CSSProperties> = {
   logo: {
     display: 'flex',
     alignItems: 'center',
-    gap: 10,
-  },
-  logoIcon: {
-    fontSize: 22,
-    lineHeight: 1,
-    color: 'var(--accent-primary)',
+    gap: 14,
   },
   logoTitle: {
-    fontSize: 20,
+    fontSize: 26,
     fontWeight: 700,
-    color: 'var(--text-primary)',
-    fontFamily: 'monospace',
-    letterSpacing: '-0.3px',
+    fontFamily: 'var(--font-display)',
+    letterSpacing: '-0.02em',
+    lineHeight: 1,
+    background: 'linear-gradient(135deg, var(--text-primary) 0%, var(--accent-primary) 110%)',
+    WebkitBackgroundClip: 'text',
+    backgroundClip: 'text',
+    color: 'transparent',
   },
   subtitle: {
     margin: 0,
     fontSize: 13,
     color: 'var(--text-secondary)',
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-display)',
+    fontWeight: 400,
+    letterSpacing: '0.01em',
   },
   section: {
     display: 'flex',
     flexDirection: 'column',
-    gap: 8,
+    gap: 10,
   },
   sectionLabel: {
-    fontSize: 11,
+    fontSize: 10,
     fontWeight: 600,
     color: 'var(--text-muted)',
     textTransform: 'uppercase',
-    letterSpacing: '0.08em',
-    fontFamily: 'monospace',
+    letterSpacing: '0.1em',
+    fontFamily: 'var(--font-display)',
   },
   emptyState: {
-    padding: '14px 12px',
+    padding: '20px 16px',
     color: 'var(--text-secondary)',
     fontSize: 13,
-    fontFamily: 'monospace',
-    background: 'var(--bg-raised)',
-    borderRadius: 6,
-    border: '1px solid var(--border-default)',
+    fontFamily: 'var(--font-display)',
+    background: 'transparent',
+    borderRadius: 8,
+    border: '1.5px dashed var(--border-default)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 8,
   },
   sessionList: {
     display: 'flex',
@@ -244,11 +336,12 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 6,
     border: '1px solid transparent',
     cursor: 'default',
-    transition: 'background 0.1s, border-color 0.1s',
+    transition: 'background 140ms var(--ease-out-expo), border-color 140ms, box-shadow 160ms',
   },
   sessionRowHover: {
     background: 'var(--bg-raised)',
     border: '1px solid var(--border-default)',
+    boxShadow: '0 0 0 1px var(--accent-primary-08)',
   },
   sessionInfo: {
     display: 'flex',
@@ -261,7 +354,8 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 14,
     fontWeight: 600,
     color: 'var(--text-primary)',
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-display)',
+    letterSpacing: '0.01em',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
@@ -269,7 +363,7 @@ const styles: Record<string, React.CSSProperties> = {
   sessionPath: {
     fontSize: 11,
     color: 'var(--text-muted)',
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-mono)',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
@@ -284,12 +378,12 @@ const styles: Record<string, React.CSSProperties> = {
   sessionPanes: {
     fontSize: 11,
     color: 'var(--text-secondary)',
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-mono)',
   },
   sessionTime: {
     fontSize: 11,
     color: 'var(--text-muted)',
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-mono)',
   },
   sessionActions: {
     display: 'flex',
@@ -298,15 +392,18 @@ const styles: Record<string, React.CSSProperties> = {
     flexShrink: 0,
   },
   openBtn: {
-    padding: '5px 12px',
+    padding: '6px 14px',
     background: 'var(--accent-primary)',
     color: 'var(--bg-base)',
     border: 'none',
-    borderRadius: 4,
+    borderRadius: 5,
     cursor: 'pointer',
     fontSize: 12,
     fontWeight: 700,
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-display)',
+    letterSpacing: '0.01em',
+    boxShadow: 'var(--glow-accent)',
+    transition: 'box-shadow 160ms, transform 160ms var(--ease-out-expo)',
   },
   deleteBtn: {
     padding: '4px 7px',
@@ -316,14 +413,14 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 4,
     cursor: 'pointer',
     fontSize: 11,
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-mono)',
     transition: 'opacity 0.15s',
   },
   newSection: {
     display: 'flex',
     flexDirection: 'column',
     gap: 10,
-    paddingTop: 4,
+    paddingTop: 12,
     borderTop: '1px solid var(--border-default)',
   },
   newRow: {
@@ -332,40 +429,73 @@ const styles: Record<string, React.CSSProperties> = {
   },
   pathInput: {
     flex: 1,
-    padding: '8px 10px',
+    padding: '9px 12px',
     background: 'var(--bg-raised)',
     color: 'var(--text-primary)',
     border: '1px solid var(--border-default)',
-    borderRadius: 5,
-    fontFamily: 'monospace',
+    borderRadius: 6,
+    fontFamily: 'var(--font-mono)',
     fontSize: 13,
     outline: 'none',
+    transition: 'border-color 160ms, box-shadow 200ms var(--ease-out-expo)',
+  },
+  pathInputFocused: {
+    borderColor: 'var(--accent-primary)',
+    boxShadow: 'var(--glow-accent)',
   },
   browseBtn: {
     padding: '8px 14px',
-    background: 'var(--bg-overlay)',
+    background: 'transparent',
     color: 'var(--text-primary)',
     border: '1px solid var(--border-default)',
-    borderRadius: 5,
+    borderRadius: 6,
     cursor: 'pointer',
     fontSize: 12,
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-display)',
+    fontWeight: 600,
+    letterSpacing: '0.01em',
     flexShrink: 0,
+    transition: 'border-color 160ms, background 160ms',
   },
   startBtn: {
-    padding: '8px 18px',
+    padding: '8px 20px',
     background: 'var(--accent-primary)',
     color: 'var(--bg-base)',
     border: 'none',
-    borderRadius: 5,
+    borderRadius: 6,
     cursor: 'pointer',
     fontWeight: 700,
-    fontFamily: 'monospace',
+    fontFamily: 'var(--font-display)',
     fontSize: 13,
+    letterSpacing: '0.01em',
     flexShrink: 0,
+    boxShadow: 'var(--glow-accent)',
+    transition: 'box-shadow 160ms, transform 120ms var(--ease-out-back)',
   },
   startBtnDisabled: {
-    opacity: 0.4,
+    opacity: 'var(--disabled-opacity)' as unknown as number,
     cursor: 'not-allowed',
+    boxShadow: 'none',
+  },
+  hint: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    fontSize: 11,
+    color: 'var(--text-muted)',
+    fontFamily: 'var(--font-display)',
+    paddingTop: 2,
+  },
+  kbd: {
+    padding: '1px 6px',
+    border: '1px solid var(--border-default)',
+    borderRadius: 4,
+    fontSize: 10,
+    fontFamily: 'var(--font-mono)',
+    color: 'var(--text-secondary)',
+    letterSpacing: '0.04em',
+  },
+  dot: {
+    opacity: 0.5,
   },
 };

--- a/frontend/src/components/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/WorkspaceSwitcher.tsx
@@ -6,20 +6,44 @@ import { useSend } from '../context/SendContext';
 import { listModes } from '../modes/registry';
 import type { WorkspaceMode } from '../domain/workspace/types';
 
+// Legacy extension of app state — WorkspaceSwitcher predates a formal
+// workspace-state contract. Cast narrowly rather than via `any`.
+interface LegacyWorkspace {
+  id: string;
+  name: string;
+  mode: WorkspaceMode;
+}
+interface LegacySessionLike {
+  project_root?: string;
+}
+interface LegacyStateShape {
+  workspaces?: Map<string, LegacyWorkspace> | { values?: () => Iterable<LegacyWorkspace> };
+  sessions?: Map<string, LegacySessionLike> | { values?: () => Iterable<LegacySessionLike> };
+  activeWorkspaceId?: string;
+}
+
+function valuesOf<T>(source: unknown): T[] {
+  if (!source || typeof source !== 'object') return [];
+  const maybeValues = (source as { values?: () => Iterable<T> }).values;
+  if (typeof maybeValues !== 'function') return [];
+  return Array.from(maybeValues.call(source));
+}
+
 export function WorkspaceSwitcher() {
   const state = useAppState();
+  const legacy = state as unknown as LegacyStateShape;
   const send = useSend();
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState('');
   const [newMode, setNewMode] = useState<WorkspaceMode>('AiSession');
 
   const modes = listModes();
-  const workspaces = Array.from((state as any).workspaces?.values?.() ?? []);
+  const workspaces = valuesOf<LegacyWorkspace>(legacy.workspaces);
 
   const handleCreate = () => {
     if (!newName.trim() || !state.activeSession) return;
-    const sessions = Array.from((state as any).sessions?.values?.() ?? []);
-    const session = sessions[0] as any;
+    const sessions = valuesOf<LegacySessionLike>(legacy.sessions);
+    const session = sessions[0];
     if (!session) return;
     send({
       type: 'CreateWorkspace',
@@ -52,7 +76,7 @@ export function WorkspaceSwitcher() {
         WORKSPACES
       </div>
 
-      {(workspaces as any[]).map((ws: any) => (
+      {workspaces.map((ws) => (
         <div
           key={ws.id}
           onClick={() => handleActivate(ws.id)}
@@ -60,8 +84,8 @@ export function WorkspaceSwitcher() {
             padding: '6px 8px',
             borderRadius: 4,
             cursor: 'pointer',
-            backgroundColor: (state as any).activeWorkspaceId === ws.id ? '#1e2a3e' : 'transparent',
-            border: (state as any).activeWorkspaceId === ws.id ? '1px solid #4ecdc4' : '1px solid transparent',
+            backgroundColor: legacy.activeWorkspaceId === ws.id ? '#1e2a3e' : 'transparent',
+            border: legacy.activeWorkspaceId === ws.id ? '1px solid #4ecdc4' : '1px solid transparent',
             fontSize: 12,
             fontFamily: 'monospace',
             color: '#e0e0e0',

--- a/frontend/src/components/sidebar/ChangesView.tsx
+++ b/frontend/src/components/sidebar/ChangesView.tsx
@@ -16,21 +16,49 @@ function getStatusChar(status: FileStatus): string {
 
 function getStatusBadgeStyle(status: FileStatus): React.CSSProperties {
   const base: React.CSSProperties = {
-    width: 14,
-    height: 14,
-    borderRadius: 2,
+    minWidth: 18,
+    height: 16,
+    padding: '0 5px',
+    borderRadius: 8,
     fontSize: 9,
-    fontWeight: 'bold',
+    fontWeight: 700,
+    letterSpacing: '0.04em',
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
+    transition: 'transform 150ms var(--ease-out-back)',
   };
-  if (status === 'Added') return { ...base, backgroundColor: 'rgba(78,205,196,0.18)', color: 'var(--accent-primary)' };
-  if (status === 'Modified') return { ...base, backgroundColor: 'rgba(240,165,0,0.18)', color: 'var(--accent-warn)' };
-  if (status === 'Deleted') return { ...base, backgroundColor: 'rgba(255,107,107,0.18)', color: 'var(--accent-error)' };
-  if (typeof status === 'object' && 'Renamed' in status) return { ...base, backgroundColor: 'rgba(136,136,136,0.18)', color: 'var(--text-muted)' };
-  return { ...base, backgroundColor: 'rgba(136,136,136,0.18)', color: 'var(--text-muted)' };
+  if (status === 'Added') return {
+    ...base,
+    backgroundColor: 'var(--accent-primary-15)',
+    color: 'var(--accent-primary)',
+    border: '1px solid rgba(var(--accent-primary-rgb), 0.35)',
+  };
+  if (status === 'Modified') return {
+    ...base,
+    backgroundColor: 'rgba(var(--accent-warn-rgb), 0.15)',
+    color: 'var(--accent-warn)',
+    border: '1px solid rgba(var(--accent-warn-rgb), 0.35)',
+  };
+  if (status === 'Deleted') return {
+    ...base,
+    backgroundColor: 'rgba(var(--accent-error-rgb), 0.15)',
+    color: 'var(--accent-error)',
+    border: '1px solid rgba(var(--accent-error-rgb), 0.35)',
+  };
+  if (typeof status === 'object' && 'Renamed' in status) return {
+    ...base,
+    backgroundColor: 'rgba(136,136,136,0.14)',
+    color: 'var(--text-secondary)',
+    border: '1px solid var(--border-default)',
+  };
+  return {
+    ...base,
+    backgroundColor: 'rgba(136,136,136,0.14)',
+    color: 'var(--text-muted)',
+    border: '1px solid var(--border-default)',
+  };
 }
 
 function isRunActive(state: { type: string }): boolean {
@@ -53,11 +81,13 @@ const contextBannerStyle: React.CSSProperties = {
 };
 
 const sectionHeaderStyle: React.CSSProperties = {
-  padding: '4px 12px 2px',
+  padding: '8px 12px 4px',
   fontSize: 10,
+  fontFamily: 'var(--font-display)',
+  fontWeight: 600,
   color: 'var(--text-muted)',
   textTransform: 'uppercase',
-  letterSpacing: '0.5px',
+  letterSpacing: '0.1em',
 };
 
 const fileRowBaseStyle: React.CSSProperties = {
@@ -145,7 +175,14 @@ function FileRow({
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
     >
-      <span style={getStatusBadgeStyle(file.status)}>{getStatusChar(file.status)}</span>
+      <span
+        style={{
+          ...getStatusBadgeStyle(file.status),
+          transform: hover ? 'scale(1.12)' : 'scale(1)',
+        }}
+      >
+        {getStatusChar(file.status)}
+      </span>
       <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, color: 'var(--text-primary)' }}>
         {file.path}
       </span>

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -373,10 +373,12 @@ export function AppProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAppState() {
   return useContext(AppStateContext);
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAppDispatch() {
   return useContext(AppDispatchContext);
 }

--- a/frontend/src/context/SendContext.tsx
+++ b/frontend/src/context/SendContext.tsx
@@ -5,6 +5,7 @@ const SendContext = createContext<(cmd: AppCommand) => void>(() => {});
 
 export const SendProvider = SendContext.Provider;
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useSend() {
   return useContext(SendContext);
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,6 @@
+import '@fontsource-variable/inter/index.css';
 import './styles/tokens.css';
+import './styles/animations.css';
 import { loadSavedTheme } from './styles/themes';
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/frontend/src/panes/PaneRenderer.tsx
+++ b/frontend/src/panes/PaneRenderer.tsx
@@ -68,39 +68,45 @@ function PaneHeader({ kind, label, focused, paneIndex, canClose, onSplitH, onSpl
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
-        height: 'var(--pane-header-height, 28px)',
+        height: 'var(--pane-header-height, 32px)',
         flexShrink: 0,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        paddingLeft: focused ? 7 : 10,
+        paddingLeft: focused ? 9 : 12,
         paddingRight: 6,
         userSelect: 'none',
         backgroundColor: focused ? 'var(--bg-overlay)' : 'var(--bg-surface)',
         borderBottom: focused
-          ? '2px solid var(--accent-primary)'
+          ? '1px solid var(--accent-primary)'
           : '1px solid var(--border-default)',
         borderLeft: focused ? '3px solid var(--accent-primary)' : '3px solid transparent',
-        boxShadow: focused ? 'inset 0 -2px 0 var(--accent-primary)' : 'none',
+        boxShadow: focused
+          ? 'inset 0 -2px 0 var(--accent-primary), var(--glow-accent)'
+          : 'none',
         boxSizing: 'border-box',
+        transition: 'background-color 160ms var(--ease-out-expo), box-shadow 200ms var(--ease-out-expo), border-color 160ms',
       }}
     >
       <span
         style={{
-          fontSize: 'var(--font-size-chrome, 11px)',
-          letterSpacing: '0.02em',
-          textTransform: 'uppercase',
+          fontFamily: 'var(--font-display)',
+          fontSize: 'var(--font-size-label, 12px)',
+          fontWeight: 600,
+          letterSpacing: '0.01em',
           display: 'flex',
           alignItems: 'center',
-          gap: 5,
+          gap: 8,
         }}
       >
         <span style={{
           color: focused ? 'var(--accent-primary, #4ecdc4)' : 'var(--text-muted, #888)',
-          fontWeight: focused ? 700 : 400,
+          fontWeight: 700,
           fontSize: '10px',
-          minWidth: 12,
+          fontFamily: 'var(--font-mono)',
+          minWidth: 14,
           textAlign: 'center',
+          transition: 'color 160ms',
         }}>{paneIndex}</span>
         {editing ? (
           <input
@@ -118,17 +124,21 @@ function PaneHeader({ kind, label, focused, paneIndex, canClose, onSplitH, onSpl
               border: 'none',
               borderBottom: '1px solid var(--accent-primary)',
               color: 'var(--text-primary)',
-              fontSize: 'var(--font-size-chrome, 11px)',
-              fontFamily: 'monospace',
+              fontSize: 'var(--font-size-label, 12px)',
+              fontFamily: 'var(--font-display)',
+              fontWeight: 600,
               outline: 'none',
-              width: 120,
-              textTransform: 'uppercase',
-              letterSpacing: '0.02em',
+              width: 140,
+              letterSpacing: '0.01em',
             }}
           />
         ) : (
           <span
-            style={{ color: focused ? 'var(--text-primary, #e0e0e0)' : 'var(--text-muted, #888)', cursor: 'text' }}
+            style={{
+              color: focused ? 'var(--text-primary, #e0e0e0)' : 'var(--text-secondary, #aaa)',
+              cursor: 'text',
+              transition: 'color 160ms',
+            }}
             onDoubleClick={(e) => { e.stopPropagation(); startEdit(); }}
           >
             {displayLabel}
@@ -486,10 +496,16 @@ export function PaneRenderer({
             cursor: sp.isHorizontal ? 'col-resize' : 'row-resize',
             zIndex: 20,
             backgroundColor: 'transparent',
-            transition: 'background-color 150ms',
+            transition: 'background-color 160ms var(--ease-out-expo), box-shadow 160ms var(--ease-out-expo)',
           }}
-          onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'rgba(78, 205, 196, 0.3)'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--accent-primary-25)';
+            e.currentTarget.style.boxShadow = 'var(--glow-accent)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'transparent';
+            e.currentTarget.style.boxShadow = 'none';
+          }}
           onMouseDown={(e) => {
             e.preventDefault();
             const container = containerRef.current;

--- a/frontend/src/panes/browser/BrowserPane.tsx
+++ b/frontend/src/panes/browser/BrowserPane.tsx
@@ -1,21 +1,42 @@
 // BrowserPane — embedded browser with URL bar and navigation (M6-01)
 
 import { useRef, useState } from 'react';
+import { ArrowLeft, ArrowRight, RotateCw, Globe } from 'lucide-react';
 import { registerPane } from '../registry';
 import type { PaneProps } from '../registry';
 
-const navButtonStyle: React.CSSProperties = {
-  background: 'none',
-  border: 'none',
-  color: 'var(--text-muted)',
-  cursor: 'pointer',
-  padding: '0 6px',
-  fontSize: 16,
-};
+function NavButton({ onClick, title, children }: { onClick: () => void; title: string; children: React.ReactNode }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      title={title}
+      style={{
+        width: 28,
+        height: 28,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: hover ? 'var(--accent-primary-08)' : 'transparent',
+        border: 'none',
+        color: hover ? 'var(--accent-primary)' : 'var(--text-muted)',
+        cursor: 'pointer',
+        borderRadius: 6,
+        padding: 0,
+        transition: 'color 140ms var(--ease-out-expo), background 140ms var(--ease-out-expo)',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
 
 export function BrowserPane({ pane: _pane }: PaneProps) {
   const [url, setUrl] = useState('about:blank');
   const [input, setInput] = useState('');
+  const [inputFocused, setInputFocused] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const navigate = (destination: string) => {
@@ -29,15 +50,15 @@ export function BrowserPane({ pane: _pane }: PaneProps) {
   };
 
   const goBack = () => {
-    try { iframeRef.current?.contentWindow?.history.back(); } catch {}
+    try { iframeRef.current?.contentWindow?.history.back(); } catch { /* cross-origin */ }
   };
 
   const goForward = () => {
-    try { iframeRef.current?.contentWindow?.history.forward(); } catch {}
+    try { iframeRef.current?.contentWindow?.history.forward(); } catch { /* cross-origin */ }
   };
 
   const reload = () => {
-    try { iframeRef.current?.contentWindow?.location.reload(); } catch {}
+    try { iframeRef.current?.contentWindow?.location.reload(); } catch { /* cross-origin */ }
   };
 
   return (
@@ -48,40 +69,49 @@ export function BrowserPane({ pane: _pane }: PaneProps) {
           display: 'flex',
           alignItems: 'center',
           gap: 4,
-          padding: '4px 8px',
+          padding: '6px 8px',
           borderBottom: '1px solid var(--border-default)',
           backgroundColor: 'var(--bg-surface)',
         }}
       >
-        <button onClick={goBack} style={navButtonStyle} title="Back">←</button>
-        <button onClick={goForward} style={navButtonStyle} title="Forward">→</button>
-        <button onClick={reload} style={navButtonStyle} title="Reload">↻</button>
+        <NavButton onClick={goBack} title="Back"><ArrowLeft size={16} strokeWidth={1.75} /></NavButton>
+        <NavButton onClick={goForward} title="Forward"><ArrowRight size={16} strokeWidth={1.75} /></NavButton>
+        <NavButton onClick={reload} title="Reload"><RotateCw size={14} strokeWidth={1.75} /></NavButton>
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          onFocus={() => setInputFocused(true)}
+          onBlur={() => setInputFocused(false)}
           onKeyDown={(e) => { if (e.key === 'Enter') navigate(input); }}
           placeholder="Enter URL..."
           style={{
             flex: 1,
-            backgroundColor: 'var(--bg-surface)',
-            border: '1px solid var(--border-default)',
+            backgroundColor: 'var(--bg-raised)',
+            border: `1px solid ${inputFocused ? 'var(--accent-primary)' : 'var(--border-default)'}`,
             color: 'var(--text-primary)',
-            padding: '4px 8px',
-            borderRadius: 3,
-            fontFamily: 'monospace',
+            padding: '5px 10px',
+            borderRadius: 5,
+            fontFamily: 'var(--font-mono)',
             fontSize: 12,
+            outline: 'none',
+            boxShadow: inputFocused ? 'var(--glow-accent)' : 'none',
+            transition: 'border-color 160ms, box-shadow 200ms var(--ease-out-expo)',
           }}
         />
         <button
           onClick={() => navigate(input)}
           style={{
             backgroundColor: 'var(--accent-primary)',
-            color: 'var(--bg-surface)',
+            color: 'var(--bg-base)',
             border: 'none',
-            borderRadius: 3,
-            padding: '4px 10px',
+            borderRadius: 5,
+            padding: '5px 14px',
             cursor: 'pointer',
+            fontFamily: 'var(--font-display)',
+            fontWeight: 600,
             fontSize: 12,
+            letterSpacing: '0.02em',
+            boxShadow: 'var(--glow-accent)',
           }}
         >
           Go
@@ -91,17 +121,21 @@ export function BrowserPane({ pane: _pane }: PaneProps) {
       {/* Iframe */}
       {url === 'about:blank' ? (
         <div style={{
-          flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
-          flexDirection: 'column', gap: 8, color: 'var(--text-muted)', fontSize: 13,
-          fontFamily: 'var(--font-mono)', backgroundColor: 'var(--bg-surface)',
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          gap: 10,
+          color: 'var(--text-muted)',
+          fontSize: 13,
+          fontFamily: 'var(--font-display)',
+          backgroundColor: 'var(--bg-surface)',
         }}>
-          <span style={{ fontSize: 24 }}>🌐</span>
-          <span>Enter a URL above to browse</span>
-          <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
-            Note: some sites block iframe embedding (e.g. Google)
-          </span>
-          <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
-            Try: localhost URLs, docs, or sites that allow embedding
+          <Globe size={32} strokeWidth={1.4} style={{ color: 'var(--accent-primary)', opacity: 0.7 }} />
+          <span>enter a URL above to browse</span>
+          <span style={{ fontSize: 11, color: 'var(--text-muted)', maxWidth: 360, textAlign: 'center', lineHeight: 1.5 }}>
+            some sites block iframe embedding — try localhost URLs, docs, or sites that allow embedding
           </span>
         </div>
       ) : (

--- a/frontend/src/panes/browser/useBrowserNavigation.ts
+++ b/frontend/src/panes/browser/useBrowserNavigation.ts
@@ -28,7 +28,7 @@ export function useBrowserNavigation() {
    */
   const openRemoteUrl = useCallback((remoteUrl: string) => {
     // Convert git remote URLs (ssh/git protocol) to HTTPS for browser
-    let webUrl = remoteUrl
+    const webUrl = remoteUrl
       .replace(/^git@github\.com:/, 'https://github.com/')
       .replace(/^git@gitlab\.com:/, 'https://gitlab.com/')
       .replace(/\.git$/, '');

--- a/frontend/src/panes/git/GitHistoryPane.tsx
+++ b/frontend/src/panes/git/GitHistoryPane.tsx
@@ -1,10 +1,36 @@
 // GitHistoryPane — commit history with branch actions (M5-01, M5-03)
 
 import { useEffect } from 'react';
+import { RotateCw } from 'lucide-react';
 import { useSend } from '../../context/SendContext';
 import { useAppState } from '../../context/AppContext';
 import { registerPane } from '../registry';
 import type { PaneProps } from '../registry';
+
+// Muted author palette — keeps the rail calm, not rainbow-loud.
+const AUTHOR_PALETTE = [
+  '#7aa2f7', // blue
+  '#b48ead', // mauve
+  '#e5a33d', // gold
+  '#9ccfd8', // sea
+  '#c4a7e7', // lilac
+  '#e0af68', // ochre
+];
+
+function hashAuthor(author: string): number {
+  let h = 0;
+  for (let i = 0; i < author.length; i++) h = (h * 31 + author.charCodeAt(i)) >>> 0;
+  return h % AUTHOR_PALETTE.length;
+}
+
+function authorColor(author: string): string {
+  return AUTHOR_PALETTE[hashAuthor(author)];
+}
+
+function authorInitial(author: string): string {
+  const trimmed = author.trim();
+  return trimmed ? trimmed[0].toUpperCase() : '?';
+}
 
 export function GitHistoryPane({ pane: _pane }: PaneProps) {
   const send = useSend();
@@ -29,10 +55,14 @@ export function GitHistoryPane({ pane: _pane }: PaneProps) {
     >
       <div
         style={{
-          padding: '8px 12px',
+          padding: '8px 14px',
           borderBottom: '1px solid var(--border-default)',
-          fontSize: 12,
+          fontSize: 11,
           color: 'var(--text-muted)',
+          fontFamily: 'var(--font-display)',
+          fontWeight: 600,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
           display: 'flex',
           alignItems: 'center',
         }}
@@ -40,37 +70,187 @@ export function GitHistoryPane({ pane: _pane }: PaneProps) {
         <span>Commit History</span>
         <button
           onClick={() => send({ type: 'GetCommitHistory', limit: 50 })}
-          style={{ marginLeft: 'auto', background: 'none', border: '1px solid var(--border-default)', color: 'var(--text-muted)', borderRadius: 3, padding: '2px 8px', cursor: 'pointer', fontSize: 11 }}
+          title="Refresh"
+          style={{
+            marginLeft: 'auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 22,
+            height: 22,
+            background: 'transparent',
+            border: '1px solid var(--border-default)',
+            color: 'var(--text-muted)',
+            borderRadius: 4,
+            cursor: 'pointer',
+            padding: 0,
+            transition: 'color 140ms, border-color 140ms, background 140ms',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = 'var(--accent-primary)';
+            e.currentTarget.style.borderColor = 'var(--accent-primary)';
+            e.currentTarget.style.background = 'var(--accent-primary-08)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = 'var(--text-muted)';
+            e.currentTarget.style.borderColor = 'var(--border-default)';
+            e.currentTarget.style.background = 'transparent';
+          }}
         >
-          ↻
+          <RotateCw size={12} strokeWidth={1.75} />
         </button>
       </div>
-      <div style={{ flex: 1, overflow: 'auto' }}>
+      <div style={{ flex: 1, overflow: 'auto', position: 'relative' }}>
         {commits.length === 0 ? (
-          <div style={{ padding: '16px 12px', color: 'var(--text-muted)', fontSize: 12, fontFamily: 'monospace' }}>
-            No commits yet
-          </div>
+          <CommitSkeleton />
         ) : (
-          commits.map((commit) => (
+          <div style={{ position: 'relative' }}>
+            {/* Vertical rail */}
             <div
-              key={commit.hash}
+              aria-hidden="true"
               style={{
-                padding: '8px 12px',
-                borderBottom: '1px solid var(--border-default)',
-                fontSize: 12,
-                fontFamily: 'monospace',
+                position: 'absolute',
+                left: 24,
+                top: 14,
+                bottom: 14,
+                width: 2,
+                background: 'rgba(var(--accent-primary-rgb), 0.28)',
+                borderRadius: 1,
               }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
-                <span style={{ color: 'var(--accent-warn)', fontSize: 10 }}>{commit.hash.slice(0, 7)}</span>
-                <span style={{ color: 'var(--text-muted)', fontSize: 10 }}>{commit.author}</span>
-                <span style={{ color: 'var(--text-muted)', fontSize: 10, marginLeft: 'auto' }}>{commit.date}</span>
+            />
+            {commits.map((commit) => (
+              <div
+                key={commit.hash}
+                style={{
+                  position: 'relative',
+                  padding: '10px 12px 10px 44px',
+                  borderBottom: '1px solid var(--border-default)',
+                  fontSize: 12,
+                }}
+              >
+                {/* Rail node (author avatar) */}
+                <div
+                  style={{
+                    position: 'absolute',
+                    left: 14,
+                    top: 12,
+                    width: 22,
+                    height: 22,
+                    borderRadius: '50%',
+                    background: authorColor(commit.author),
+                    color: 'var(--bg-base)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontFamily: 'var(--font-display)',
+                    fontWeight: 700,
+                    fontSize: 11,
+                    boxShadow: '0 0 0 3px var(--bg-surface)',
+                  }}
+                  title={commit.author}
+                >
+                  {authorInitial(commit.author)}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                  <span
+                    style={{
+                      color: 'var(--accent-warn)',
+                      fontSize: 10,
+                      fontFamily: 'var(--font-mono)',
+                      padding: '1px 5px',
+                      border: '1px solid rgba(var(--accent-warn-rgb), 0.3)',
+                      borderRadius: 3,
+                      background: 'rgba(var(--accent-warn-rgb), 0.08)',
+                    }}
+                  >
+                    {commit.hash.slice(0, 7)}
+                  </span>
+                  <span
+                    style={{
+                      color: 'var(--text-secondary)',
+                      fontSize: 11,
+                      fontFamily: 'var(--font-display)',
+                    }}
+                  >
+                    {commit.author}
+                  </span>
+                  <span
+                    style={{
+                      color: 'var(--text-muted)',
+                      fontSize: 10,
+                      fontFamily: 'var(--font-mono)',
+                      marginLeft: 'auto',
+                    }}
+                  >
+                    {commit.date}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    color: 'var(--text-primary)',
+                    wordBreak: 'break-word',
+                    fontFamily: 'var(--font-display)',
+                    fontSize: 13,
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {commit.message}
+                </div>
               </div>
-              <div style={{ color: 'var(--text-primary)', wordBreak: 'break-word' }}>{commit.message}</div>
-            </div>
-          ))
+            ))}
+          </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function CommitSkeleton() {
+  const rows = [0, 1, 2, 3];
+  return (
+    <div style={{ position: 'relative', padding: 0 }}>
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: 24,
+          top: 14,
+          bottom: 14,
+          width: 2,
+          background: 'rgba(var(--accent-primary-rgb), 0.15)',
+          borderRadius: 1,
+        }}
+      />
+      {rows.map((i) => (
+        <div
+          key={i}
+          style={{
+            position: 'relative',
+            padding: '12px 12px 12px 44px',
+            borderBottom: '1px solid var(--border-default)',
+          }}
+        >
+          <div
+            className="anim-shimmer"
+            style={{
+              position: 'absolute',
+              left: 14,
+              top: 12,
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+            }}
+          />
+          <div
+            className="anim-shimmer"
+            style={{ height: 10, width: '40%', borderRadius: 4, marginBottom: 8 }}
+          />
+          <div
+            className="anim-shimmer"
+            style={{ height: 12, width: `${70 - i * 10}%`, borderRadius: 4 }}
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/panes/git/GitStatusPane.tsx
+++ b/frontend/src/panes/git/GitStatusPane.tsx
@@ -1,6 +1,7 @@
 // GitStatusPane — repository status with stage/unstage/commit actions (M5-01, M5-03)
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { GitBranch, RotateCw } from 'lucide-react';
 import { useSend } from '../../context/SendContext';
 import { useAppState } from '../../context/AppContext';
 import { registerPane } from '../registry';
@@ -15,16 +16,51 @@ function statusLabel(status: FileChange['status']): string {
   return '?';
 }
 
-function statusColor(status: FileChange['status']): string {
-  if (status === 'Added') return 'var(--accent-primary)';
-  if (status === 'Modified') return 'var(--accent-warn)';
-  if (status === 'Deleted') return 'var(--accent-error)';
-  return 'var(--text-muted)';
+function pillStyle(status: FileChange['status']): React.CSSProperties {
+  const base: React.CSSProperties = {
+    minWidth: 20,
+    height: 18,
+    padding: '0 6px',
+    borderRadius: 9,
+    fontSize: 10,
+    fontWeight: 700,
+    letterSpacing: '0.04em',
+    fontFamily: 'var(--font-mono)',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  };
+  if (status === 'Added') return {
+    ...base,
+    color: 'var(--accent-primary)',
+    backgroundColor: 'var(--accent-primary-15)',
+    border: '1px solid rgba(var(--accent-primary-rgb), 0.35)',
+  };
+  if (status === 'Modified') return {
+    ...base,
+    color: 'var(--accent-warn)',
+    backgroundColor: 'rgba(var(--accent-warn-rgb), 0.15)',
+    border: '1px solid rgba(var(--accent-warn-rgb), 0.35)',
+  };
+  if (status === 'Deleted') return {
+    ...base,
+    color: 'var(--accent-error)',
+    backgroundColor: 'rgba(var(--accent-error-rgb), 0.15)',
+    border: '1px solid rgba(var(--accent-error-rgb), 0.35)',
+  };
+  return {
+    ...base,
+    color: 'var(--text-muted)',
+    backgroundColor: 'rgba(136,136,136,0.14)',
+    border: '1px solid var(--border-default)',
+  };
 }
 
 export function GitStatusPane({ pane: _pane }: PaneProps) {
   const send = useSend();
   const state = useAppState();
+  const [hoverPath, setHoverPath] = useState<string | null>(null);
 
   useEffect(() => {
     send({ type: 'GetRepoStatus' });
@@ -33,6 +69,11 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
 
   const files = state.changedFiles?.files ?? [];
   const repoStatus = state.repoStatus;
+
+  const refresh = () => {
+    send({ type: 'GetRepoStatus' });
+    send({ type: 'GetChangedFiles', mode: 'working' });
+  };
 
   return (
     <div
@@ -51,70 +92,133 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
           padding: '8px 12px',
           borderBottom: '1px solid var(--border-default)',
           fontSize: 12,
-          color: 'var(--text-muted)',
+          fontFamily: 'var(--font-display)',
+          color: 'var(--text-secondary)',
           display: 'flex',
           gap: 12,
           alignItems: 'center',
         }}
       >
-        <span style={{ fontWeight: 'bold', color: 'var(--accent-primary)' }}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: 'var(--accent-primary)', fontWeight: 600 }}>
+          <GitBranch size={12} strokeWidth={2} />
           {repoStatus?.branch ?? 'unknown'}
         </span>
         {repoStatus && (
-          <span>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>
             {repoStatus.staged_count > 0 && (
               <span style={{ color: 'var(--accent-primary)' }}>+{repoStatus.staged_count} staged</span>
             )}
-            {repoStatus.staged_count > 0 && repoStatus.unstaged_count > 0 && ' · '}
+            {repoStatus.staged_count > 0 && repoStatus.unstaged_count > 0 && (
+              <span style={{ color: 'var(--text-muted)' }}> · </span>
+            )}
             {repoStatus.unstaged_count > 0 && (
               <span style={{ color: 'var(--accent-warn)' }}>{repoStatus.unstaged_count} unstaged</span>
             )}
           </span>
         )}
         <button
-          onClick={() => { send({ type: 'GetRepoStatus' }); send({ type: 'GetChangedFiles', mode: 'working' }); }}
-          style={{ marginLeft: 'auto', background: 'none', border: '1px solid var(--border-default)', color: 'var(--text-muted)', borderRadius: 3, padding: '2px 8px', cursor: 'pointer', fontSize: 11 }}
+          onClick={refresh}
+          title="Refresh"
+          style={{
+            marginLeft: 'auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            background: 'transparent',
+            border: '1px solid var(--border-default)',
+            color: 'var(--text-muted)',
+            borderRadius: 5,
+            padding: '3px 9px',
+            cursor: 'pointer',
+            fontFamily: 'var(--font-display)',
+            fontSize: 11,
+            fontWeight: 500,
+            transition: 'color 140ms, border-color 140ms, background 140ms',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = 'var(--accent-primary)';
+            e.currentTarget.style.borderColor = 'var(--accent-primary)';
+            e.currentTarget.style.background = 'var(--accent-primary-08)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = 'var(--text-muted)';
+            e.currentTarget.style.borderColor = 'var(--border-default)';
+            e.currentTarget.style.background = 'transparent';
+          }}
         >
-          ↻ Refresh
+          <RotateCw size={11} strokeWidth={1.75} />
+          Refresh
         </button>
       </div>
 
       {/* File list */}
       <div style={{ flex: 1, overflow: 'auto', padding: '4px 0' }}>
         {files.length === 0 ? (
-          <div style={{ padding: '16px 12px', color: 'var(--text-muted)', fontSize: 12, fontFamily: 'monospace' }}>
-            No changed files
+          <div
+            style={{
+              padding: '24px 12px',
+              color: 'var(--text-muted)',
+              fontSize: 12,
+              fontFamily: 'var(--font-display)',
+              textAlign: 'center',
+            }}
+          >
+            no changed files
           </div>
         ) : (
-          files.map((file) => (
-            <div
-              key={typeof file.path === 'string' ? file.path : String(file.path)}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                padding: '4px 12px',
-                gap: 8,
-                fontSize: 12,
-                fontFamily: 'monospace',
-                cursor: 'pointer',
-              }}
-              onMouseEnter={(e) => ((e.currentTarget as HTMLDivElement).style.backgroundColor = 'var(--bg-raised)')}
-              onMouseLeave={(e) => ((e.currentTarget as HTMLDivElement).style.backgroundColor = 'transparent')}
-            >
-              <span style={{ color: statusColor(file.status), width: 14, textAlign: 'center' }}>
-                {statusLabel(file.status)}
-              </span>
-              <span style={{ flex: 1 }}>
-                {typeof file.path === 'string' ? file.path : String(file.path)}
-              </span>
-              <button
-                onClick={() => send({ type: 'StageFile', path: typeof file.path === 'string' ? file.path : String(file.path) })}
-                style={{ background: 'none', border: '1px solid var(--border-default)', color: 'var(--accent-primary)', borderRadius: 3, padding: '1px 6px', cursor: 'pointer', fontSize: 10 }}
+          files.map((file) => {
+            const pathStr = typeof file.path === 'string' ? file.path : String(file.path);
+            const isHover = hoverPath === pathStr;
+            return (
+              <div
+                key={pathStr}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '5px 12px',
+                  gap: 8,
+                  fontSize: 12,
+                  fontFamily: 'var(--font-mono)',
+                  cursor: 'pointer',
+                  backgroundColor: isHover ? 'var(--bg-raised)' : 'transparent',
+                  borderLeft: isHover ? '2px solid var(--accent-primary)' : '2px solid transparent',
+                  transition: 'background-color 120ms, border-color 120ms',
+                }}
+                onMouseEnter={() => setHoverPath(pathStr)}
+                onMouseLeave={() => setHoverPath(null)}
               >
-                Stage
-              </button>
-            </div>
-          ))
+                <span style={pillStyle(file.status)}>{statusLabel(file.status)}</span>
+                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {pathStr}
+                </span>
+                <button
+                  onClick={() => send({ type: 'StageFile', path: pathStr })}
+                  style={{
+                    background: 'transparent',
+                    border: '1px solid var(--accent-primary)',
+                    color: 'var(--accent-primary)',
+                    borderRadius: 4,
+                    padding: '2px 10px',
+                    cursor: 'pointer',
+                    fontFamily: 'var(--font-display)',
+                    fontSize: 10,
+                    fontWeight: 600,
+                    letterSpacing: '0.02em',
+                    opacity: isHover ? 1 : 0.7,
+                    transition: 'opacity 120ms, background 120ms',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = 'var(--accent-primary-08)';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = 'transparent';
+                  }}
+                >
+                  Stage
+                </button>
+              </div>
+            );
+          })
         )}
       </div>
 
@@ -126,36 +230,56 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
 
 function CommitBar({ onCommit }: { onCommit: (msg: string) => void }) {
   const [msg, setMsg] = React.useState('');
+  const [focused, setFocused] = React.useState(false);
 
   return (
-    <div style={{ padding: '8px 12px', borderTop: '1px solid var(--border-default)', display: 'flex', gap: 8 }}>
+    <div
+      style={{
+        padding: '10px 12px',
+        borderTop: '1px solid var(--border-default)',
+        display: 'flex',
+        gap: 8,
+        background: 'var(--bg-base)',
+      }}
+    >
       <input
         value={msg}
         onChange={(e) => setMsg(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
         onKeyDown={(e) => { if (e.key === 'Enter' && msg.trim()) { onCommit(msg.trim()); setMsg(''); } }}
-        placeholder="Commit message..."
+        placeholder="commit message..."
         style={{
           flex: 1,
-          backgroundColor: 'var(--bg-surface)',
-          border: '1px solid var(--border-default)',
+          backgroundColor: 'var(--bg-raised)',
+          border: `1px solid ${focused ? 'var(--accent-primary)' : 'var(--border-default)'}`,
           color: 'var(--text-primary)',
-          padding: '4px 8px',
-          borderRadius: 3,
-          fontFamily: 'monospace',
+          padding: '6px 10px',
+          borderRadius: 5,
+          fontFamily: 'var(--font-mono)',
           fontSize: 12,
+          outline: 'none',
+          boxShadow: focused ? 'var(--glow-accent)' : 'none',
+          transition: 'border-color 160ms, box-shadow 200ms var(--ease-out-expo)',
         }}
       />
       <button
         onClick={() => { if (msg.trim()) { onCommit(msg.trim()); setMsg(''); } }}
+        disabled={!msg.trim()}
         style={{
-          backgroundColor: 'var(--accent-primary)',
-          color: 'var(--bg-surface)',
+          backgroundColor: msg.trim() ? 'var(--accent-primary)' : 'var(--bg-overlay)',
+          color: msg.trim() ? 'var(--bg-base)' : 'var(--text-muted)',
           border: 'none',
-          borderRadius: 3,
-          padding: '4px 12px',
-          cursor: 'pointer',
+          borderRadius: 5,
+          padding: '6px 16px',
+          cursor: msg.trim() ? 'pointer' : 'not-allowed',
+          fontFamily: 'var(--font-display)',
+          fontWeight: 700,
           fontSize: 12,
-          fontWeight: 'bold',
+          letterSpacing: '0.02em',
+          boxShadow: msg.trim() ? 'var(--glow-accent)' : 'none',
+          opacity: msg.trim() ? 1 : 'var(--disabled-opacity)' as unknown as number,
+          transition: 'background 160ms, box-shadow 200ms, opacity 160ms',
         }}
       >
         Commit

--- a/frontend/src/panes/terminal/TerminalPane.tsx
+++ b/frontend/src/panes/terminal/TerminalPane.tsx
@@ -48,6 +48,15 @@ function installGlobalListener() {
 // Global map: paneId → sessionId. Survives React remounts (e.g., after pane split).
 const paneSessionMap = new Map<string, string>();
 
+/** Minimal subset of xterm.js Terminal we use here. */
+interface XTermHandle {
+  write: (data: string) => void;
+  dispose: () => void;
+  clear?: () => void;
+  focus?: () => void;
+  options?: { theme?: unknown };
+}
+
 function getTermTheme() {
   const s = getComputedStyle(document.documentElement);
   const v = (name: string) => s.getPropertyValue(name).trim() || undefined;
@@ -72,7 +81,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
   const [sessionState, setSessionState] = useState<SessionState>(existingSessionId ? 'active' : 'idle');
   const [xtermLoaded, setXtermLoaded] = useState(false);
   const termRef = useRef<HTMLDivElement>(null);
-  const xtermRef = useRef<{ write: (data: string) => void; dispose: () => void } | null>(null);
+  const xtermRef = useRef<XTermHandle | null>(null);
 
   // Ref to hold current sessionId for use inside closures that can't track state
   const sessionIdRef = useRef<string | null>(null);
@@ -104,9 +113,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
 
     const initXterm = async () => {
       try {
-        // @ts-ignore — xterm is a peer dep loaded at runtime
         const { Terminal } = await import('xterm');
-        // @ts-ignore
         const { FitAddon } = await import('@xterm/addon-fit');
         if (disposed || !termRef.current) return;
 
@@ -170,7 +177,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
   // Update xterm theme when CSS variables change (theme switch)
   useEffect(() => {
     const observer = new MutationObserver(() => {
-      const term = xtermRef.current as any;
+      const term = xtermRef.current;
       if (term?.options) {
         term.options.theme = getTermTheme();
       }
@@ -182,7 +189,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
   // Focus xterm when this pane becomes focused (for keyboard navigation)
   useEffect(() => {
     if (focused && xtermRef.current) {
-      (xtermRef.current as any).focus?.();
+      xtermRef.current.focus?.();
     }
   }, [focused]);
 
@@ -217,7 +224,9 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
     if (sshConfig) {
       cmd.ssh = sshConfig;
     }
-    send(cmd as any);
+    // cmd is structurally an AppCommand for CreateTerminalSession — the
+    // optional `ssh` field isn't on every variant, hence the unknown cast.
+    send(cmd as unknown as Parameters<typeof send>[0]);
     waitForSession(workspaceId).then((sid) => {
       paneSessionMap.set(pane.id, sid);
       setSessionId(sid);
@@ -242,12 +251,13 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
         // Detect a shell prompt return after a git command.
         // The git pattern must appear as a command (after a prompt character),
         // not merely in output text — we check for a prompt prefix before "git".
-        const gitCmdPattern = /(?:^|[\$%>❯]\s+)git\s+(?:add|commit|checkout|switch|merge|rebase|stash|pull|push|reset|revert|cherry-pick|branch|restore|rm|mv|tag)\b/m;
+        const gitCmdPattern = /(?:^|[$%>❯]\s+)git\s+(?:add|commit|checkout|switch|merge|rebase|stash|pull|push|reset|revert|cherry-pick|branch|restore|rm|mv|tag)\b/m;
         // A prompt appearing at the end of the latest chunk signals command completion
-        const promptReturnPattern = /[\$%>❯]\s*$/;
+        const promptReturnPattern = /[$%>❯]\s*$/;
 
         if (
           gitCmdPattern.test(recentOutputRef.current) &&
+          // eslint-disable-next-line no-control-regex
           promptReturnPattern.test(event.data.replace(/\x1b\[[0-9;]*[mGKHF]/g, '').trimEnd())
         ) {
           if (gitRefreshTimerRef.current) clearTimeout(gitRefreshTimerRef.current);
@@ -258,6 +268,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
         }
 
         // Notify user when prompt returns in an unfocused pane
+        // eslint-disable-next-line no-control-regex
         if (!focusedRef.current && promptReturnPattern.test(event.data.replace(/\x1b\[[0-9;]*[mGKHF]/g, '').trimEnd())) {
           const notificationsEnabled = localStorage.getItem('terminal:notifications') !== 'false';
           if (notificationsEnabled) {
@@ -278,6 +289,8 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
     };
     window.addEventListener('terminal-event', handler);
     return () => window.removeEventListener('terminal-event', handler);
+    // pane.id and pane.label are stable per component instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
 
   // Listen for quick-command run events — only the focused pane handles them
@@ -298,7 +311,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
   useEffect(() => {
     if (sessionId && xtermLoaded) {
       const timer = setTimeout(() => {
-        const term = xtermRef.current as any;
+        const term = xtermRef.current;
         if (term) {
           // Clear xterm screen
           if (term.clear) term.clear();

--- a/frontend/src/panes/terminal/TerminalPane.tsx
+++ b/frontend/src/panes/terminal/TerminalPane.tsx
@@ -303,13 +303,26 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
           // Clear xterm screen
           if (term.clear) term.clear();
           else if (term.write) term.write('\x1b[2J\x1b[H');
+          // Show a small teal banner above the first prompt — only for local shells.
+          // Suppressed for SSH to avoid clobbering the remote MOTD. Respects opt-out.
+          const bannerEnabled = localStorage.getItem('terminal:banner') !== 'false';
+          if (bannerEnabled && !sshConfig && term.write) {
+            // ANSI: 38;2;R;G;B sets 24-bit fg color. Teal = 78,205,196.
+            const teal = '\x1b[38;2;78;205;196m';
+            const dim = '\x1b[38;2;139;143;163m';
+            const reset = '\x1b[0m';
+            const banner =
+              `${teal} ▸ Terminal Engine${reset}${dim}  ready${reset}\r\n` +
+              `${dim} ⌘K commands · ⌘/ shortcuts${reset}\r\n\r\n`;
+            term.write(banner);
+          }
           // Send Enter to PTY to trigger a fresh prompt
           sendRef.current({ type: 'WriteTerminalInput', session_id: sessionId, data: '\n' });
         }
       }, 800);
       return () => clearTimeout(timer);
     }
-  }, [sessionId, xtermLoaded]);
+  }, [sessionId, xtermLoaded, sshConfig]);
 
   const handleReconnect = () => {
     paneSessionMap.delete(pane.id);
@@ -333,20 +346,31 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
             zIndex: 10,
           }}
         >
-          <span style={{ color: 'var(--accent-error)', fontFamily: 'monospace', fontSize: 14 }}>
-            Session lost
+          <span
+            style={{
+              color: 'var(--accent-error)',
+              fontFamily: 'var(--font-display)',
+              fontWeight: 600,
+              fontSize: 14,
+              letterSpacing: '0.01em',
+            }}
+          >
+            session lost
           </span>
           <button
             onClick={handleReconnect}
             style={{
-              padding: '8px 16px',
+              padding: '8px 18px',
               backgroundColor: 'var(--accent-primary)',
-              color: 'var(--bg-surface)',
+              color: 'var(--bg-base)',
               border: 'none',
-              borderRadius: 4,
+              borderRadius: 5,
               cursor: 'pointer',
-              fontFamily: 'monospace',
-              fontWeight: 'bold',
+              fontFamily: 'var(--font-display)',
+              fontWeight: 700,
+              fontSize: 12,
+              letterSpacing: '0.02em',
+              boxShadow: 'var(--glow-accent)',
             }}
           >
             Reconnect
@@ -360,16 +384,32 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
           style={{
             flex: 1,
             display: 'flex',
+            flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
+            gap: 10,
             color: 'var(--text-muted)',
-            fontFamily: 'monospace',
+            fontFamily: 'var(--font-display)',
             fontSize: 13,
+            letterSpacing: '0.01em',
           }}
         >
-          {sessionState === 'creating'
-            ? (sshConfig ? `Connecting to ${sshConfig.username}@${sshConfig.host}...` : 'Starting terminal...')
-            : 'Terminal'}
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'inline-block',
+              width: 8,
+              height: 16,
+              background: 'var(--accent-primary)',
+              borderRadius: 1,
+              animation: 'glow-pulse 1.4s ease-in-out infinite',
+            }}
+          />
+          <span>
+            {sessionState === 'creating'
+              ? (sshConfig ? `connecting to ${sshConfig.username}@${sshConfig.host}...` : 'starting terminal...')
+              : 'terminal'}
+          </span>
         </div>
       )}
     </div>

--- a/frontend/src/styles/animations.css
+++ b/frontend/src/styles/animations.css
@@ -1,0 +1,126 @@
+/* Motion language for Terminal Engine.
+ * Principle: responsive spring — fast in, ease-out heavy, GPU-only properties.
+ * All keyframes respect `prefers-reduced-motion`.
+ */
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes fade-in-up {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  @keyframes scale-in {
+    from { opacity: 0; transform: scale(0.96); }
+    to   { opacity: 1; transform: scale(1); }
+  }
+
+  @keyframes glow-pulse {
+    0%, 100% {
+      box-shadow: 0 0 8px rgba(var(--accent-primary-rgb), 0.10);
+      opacity: 0.85;
+    }
+    50% {
+      box-shadow: 0 0 22px rgba(var(--accent-primary-rgb), 0.28);
+      opacity: 1;
+    }
+  }
+
+  @keyframes soft-pulse {
+    0%, 100% { opacity: 0.65; }
+    50%      { opacity: 1; }
+  }
+
+  @keyframes check-pop {
+    0%   { transform: scale(0); }
+    60%  { transform: scale(1.2); }
+    100% { transform: scale(1); }
+  }
+
+  @keyframes slide-down {
+    from { opacity: 0; max-height: 0; }
+    to   { opacity: 1; max-height: 400px; }
+  }
+
+  @keyframes caret-blink {
+    0%, 55%  { opacity: 1; }
+    60%, 100% { opacity: 0.25; }
+  }
+
+  @keyframes sparkle-burst {
+    0%   { opacity: 1; transform: translate(0, 0) scale(1); }
+    100% { opacity: 0; transform: translate(var(--dx, 20px), var(--dy, -14px)) scale(0.4); }
+  }
+
+  @keyframes chevron-nudge {
+    0%, 100% { transform: translateY(0); }
+    50%      { transform: translateY(4px); }
+  }
+
+  @keyframes shimmer {
+    0%   { background-position: -200px 0; }
+    100% { background-position: calc(200px + 100%) 0; }
+  }
+
+  /* Reusable helpers */
+  .anim-fade-in-up {
+    animation: fade-in-up 180ms var(--ease-out-expo) both;
+  }
+  .anim-fade-in {
+    animation: fade-in 160ms var(--ease-out-soft) both;
+  }
+  .anim-scale-in {
+    animation: scale-in 200ms var(--ease-out-back) both;
+  }
+  .anim-glow-pulse {
+    animation: glow-pulse 2s ease-in-out infinite;
+  }
+  .anim-soft-pulse {
+    animation: soft-pulse 1.4s ease-in-out infinite;
+  }
+  .anim-check-pop {
+    animation: check-pop 260ms var(--ease-out-back) both;
+  }
+  .anim-chevron-nudge {
+    animation: chevron-nudge 1.6s ease-in-out infinite;
+  }
+  .anim-shimmer {
+    background: linear-gradient(
+      90deg,
+      var(--bg-raised) 0%,
+      var(--bg-overlay) 50%,
+      var(--bg-raised) 100%
+    );
+    background-size: 200px 100%;
+    animation: shimmer 1.4s linear infinite;
+  }
+
+  /* Staggered entrance (set --i on the element) */
+  .stagger-in {
+    animation: fade-in-up 220ms var(--ease-out-expo) both;
+    animation-delay: calc(var(--i, 0) * 40ms);
+  }
+}
+
+/* Reduced-motion fallback: no movement, just visible. */
+@media (prefers-reduced-motion: reduce) {
+  .anim-fade-in-up,
+  .anim-fade-in,
+  .anim-scale-in,
+  .stagger-in {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .anim-glow-pulse,
+  .anim-soft-pulse,
+  .anim-check-pop,
+  .anim-chevron-nudge,
+  .anim-shimmer {
+    animation: none;
+  }
+}

--- a/frontend/src/styles/themes.ts
+++ b/frontend/src/styles/themes.ts
@@ -8,8 +8,27 @@ export interface Theme {
 
 export const themes: Theme[] = [
   {
+    id: 'terminal-engine',
+    name: 'Terminal Engine (signature)',
+    colors: {
+      '--bg-base': '#0c0e17',
+      '--bg-surface': '#141624',
+      '--bg-raised': '#1a1d2e',
+      '--bg-overlay': '#232738',
+      '--border-default': '#2a2d3d',
+      '--border-focus': '#5fe3d9',
+      '--text-primary': '#eaecf2',
+      '--text-secondary': '#9ca0b5',
+      '--text-muted': '#616682',
+      '--accent-primary': '#5fe3d9',
+      '--accent-warn': '#ecb04a',
+      '--accent-error': '#ec6a6a',
+      '--accent-info': '#8a97f8',
+    },
+  },
+  {
     id: 'midnight',
-    name: 'Midnight (default)',
+    name: 'Midnight',
     colors: {
       '--bg-base': '#0f1119',
       '--bg-surface': '#161822',
@@ -202,6 +221,24 @@ export const themes: Theme[] = [
 
 const THEME_KEY = 'terminal:theme';
 
+/** Convert "#rrggbb" → "r, g, b" string, usable inside rgba(var(--x), a). */
+function hexToRgbTriplet(hex: string): string {
+  const normalized = hex.trim().replace(/^#/, '');
+  if (normalized.length !== 6) return '78, 205, 196'; // fallback: default teal
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  if ([r, g, b].some(Number.isNaN)) return '78, 205, 196';
+  return `${r}, ${g}, ${b}`;
+}
+
+const RGB_DERIVED = [
+  ['--accent-primary', '--accent-primary-rgb'],
+  ['--accent-warn', '--accent-warn-rgb'],
+  ['--accent-error', '--accent-error-rgb'],
+  ['--accent-info', '--accent-info-rgb'],
+] as const;
+
 export function applyTheme(themeId: string): void {
   const theme = themes.find(t => t.id === themeId);
   if (!theme) return;
@@ -209,8 +246,15 @@ export function applyTheme(themeId: string): void {
   for (const [prop, value] of Object.entries(theme.colors)) {
     root.style.setProperty(prop, value);
   }
+  // Re-derive RGB triplets so glow tokens auto-retint per theme.
+  for (const [hexVar, rgbVar] of RGB_DERIVED) {
+    const hex = theme.colors[hexVar];
+    if (hex) root.style.setProperty(rgbVar, hexToRgbTriplet(hex));
+  }
   localStorage.setItem(THEME_KEY, themeId);
 }
+
+const DEFAULT_THEME_ID = 'terminal-engine';
 
 export function loadSavedTheme(): string {
   const saved = localStorage.getItem(THEME_KEY);
@@ -218,9 +262,10 @@ export function loadSavedTheme(): string {
     applyTheme(saved);
     return saved;
   }
-  return 'midnight';
+  applyTheme(DEFAULT_THEME_ID);
+  return DEFAULT_THEME_ID;
 }
 
 export function getCurrentThemeId(): string {
-  return localStorage.getItem(THEME_KEY) ?? 'midnight';
+  return localStorage.getItem(THEME_KEY) ?? DEFAULT_THEME_ID;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -16,21 +16,59 @@
 
   /* Accents */
   --accent-primary: #4ecdc4;
+  --accent-primary-rgb: 78, 205, 196;
   --accent-warn: #e5a33d;
+  --accent-warn-rgb: 229, 163, 61;
   --accent-error: #e55a5a;
+  --accent-error-rgb: 229, 90, 90;
   --accent-info: #7c8cf5;
+  --accent-info-rgb: 124, 140, 245;
+
+  /* Accent fills (per-theme — derived from --accent-primary-rgb) */
+  --accent-primary-08: rgba(var(--accent-primary-rgb), 0.08);
+  --accent-primary-15: rgba(var(--accent-primary-rgb), 0.15);
+  --accent-primary-25: rgba(var(--accent-primary-rgb), 0.25);
+
+  /* Glow effects */
+  --glow-accent: 0 0 20px rgba(var(--accent-primary-rgb), 0.14);
+  --glow-accent-strong: 0 0 32px rgba(var(--accent-primary-rgb), 0.24);
+  --glow-error: 0 0 16px rgba(var(--accent-error-rgb), 0.18);
+  --glow-warn: 0 0 16px rgba(var(--accent-warn-rgb), 0.18);
+
+  /* Elevation shadows */
+  --shadow-elevated: 0 4px 12px rgba(0, 0, 0, 0.25), 0 1px 3px rgba(0, 0, 0, 0.15);
+  --shadow-overlay: 0 16px 48px rgba(0, 0, 0, 0.45), 0 0 1px rgba(255, 255, 255, 0.05);
+  --shadow-toast: 0 8px 24px rgba(0, 0, 0, 0.4);
+
+  /* Glass surfaces */
+  --bg-glass: rgba(22, 24, 34, 0.82);
+  --glass-border: rgba(255, 255, 255, 0.06);
+
+  /* Gradients */
+  --gradient-surface: linear-gradient(180deg, var(--bg-surface) 0%, var(--bg-base) 100%);
+
+  /* State */
+  --disabled-opacity: 0.55;
 
   /* Typography */
   --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  --font-display: "InterVariable", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
   --font-size-content: 13px;
   --font-size-chrome: 11px;
   --font-size-badge: 10px;
+  --font-size-label: 12px;
 
   /* Spacing */
   --chrome-height: 36px;
   --statusbar-height: 24px;
   --activitybar-width: 40px;
-  --pane-header-height: 28px;
+  --pane-header-height: 32px;
+
+  /* Motion — easing curves */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out-back: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-in-out-quint: cubic-bezier(0.86, 0, 0.07, 1);
+  --ease-out-soft: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 * {
@@ -44,6 +82,8 @@ body {
   font-family: var(--font-mono);
   font-size: var(--font-size-content);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 /* Custom scrollbars */
@@ -51,3 +91,9 @@ body {
 ::-webkit-scrollbar-track { background: var(--bg-surface); }
 ::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
+/* Utility class: display typography (Inter) */
+.display {
+  font-family: var(--font-display);
+  letter-spacing: 0.01em;
+}


### PR DESCRIPTION
Transform the app's feel without changing functionality. Based on a
PM + Designer audit landing on a "Calm Hacker / Modern Minimal + Joyful"
direction: precise, confident, quietly luminous — teal becomes a light
language where light = activity.

Foundation (tokens, motion, font)
- Add Inter variable display font alongside JetBrains Mono
- New depth tokens: glow-accent, glow-error, glow-warn, shadow-elevated,
  shadow-overlay, shadow-toast, bg-glass, glass-border, gradient-surface
- Per-theme RGB triplets so glows auto-retint across all 10 themes
- New animations.css: fade-in-up, scale-in, glow-pulse, check-pop,
  sparkle-burst, chevron-nudge, shimmer, caret-blink — all wrapped in
  prefers-reduced-motion
- Easing curves: ease-out-expo/back/soft

Typography & pane chrome
- PaneHeader: 28→32px, Inter 600 sentence case (was mono uppercase 11px)
- Focus ring now breathes with glow-accent instead of flat accent
- Splitters light up teal on hover (color + glow)
- AppChrome title uses gradient text, tabs use Inter 600
- ActivityBar icons sit in accent-primary-15 pool when active + scale
  on hover

Welcome hero moment
- Replace keyboard emoji with SVG terminal glyph with blinking caret
- Gradient title, radial teal spotlight backdrop
- Card enters with scale-in, session rows stagger via fade-in-up
- Dashed empty state with animated ChevronDown
- ⌘K / ⌘/ discovery hint under Start

Signature feedback
- Streaming caret in RunPanel (glow-pulse block) replaces "Running..."
- Run-complete sparkle burst (6 GPU-only dots) from exit-code badge
- Toast container gets glass + glow + variant-ready left border
- StatusBar: AI dot pulses, connection dot glows when connected
- CommandPalette: backdrop blur, glass surface, overlay shadow + glow

Git UX
- GitHistoryPane: vertical commit rail with author-hashed colored
  avatar circles, shimmer skeleton loaders while loading
- Pill-shaped status badges (A/M/D/R) that scale on hover
- Section headers use Inter display

Button hierarchy & icon sweep
- BrowserPane: lucide ArrowLeft/ArrowRight/RotateCw/Globe replace
  Unicode symbols; focus ring on URL input
- GitStatusPane: pill badges, ghost Stage buttons, focus-ring on
  commit input, disabled state uses --disabled-opacity
- Inter for all button labels, primary buttons carry glow-accent

Signature touches
- New "Terminal Engine" signature theme (default) — amplified teal
- ANSI teal welcome banner on local terminal pane open
  (suppressed for SSH; opt-out via localStorage terminal:banner=false)
- Terminal session-lost / loading screens use glow-pulse caret