### PR TITLE
TERMINAL-M7-03: Add contributor docs for modes, panes, and UX conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ cd frontend && npm run build
 
 Rust MSRV: **1.88** (required by `time` crate). Dockerfiles use `rust:1.88-slim`.
 
+## Architecture & Contributor Docs
+
+Detailed platform documentation lives in `docs/`:
+- [Architecture](docs/architecture.md) | [Modes](docs/modes.md) | [Panes](docs/panes.md)
+- [Workspaces](docs/workspaces.md) | [UX](docs/ux-conventions.md) | [Keybindings](docs/keybindings.md)
+- [Naming](docs/naming-conventions.md)
+
+CLAUDE.md stays lean (build/test/conventions). Architecture detail lives in `docs/`.
+
 ## Architecture Overview
 
 ### Daemon Architecture

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,139 +1,174 @@
-# AI Dev Terminal — Arquitetura Técnica (Opção 2)
+# Architecture
 
-Este documento define uma arquitetura prática para um terminal unificado que combina:
-- Operações com Claude Code por comandos simples.
-- Fluxos Git intuitivos e seguros.
+Terminal Engine is a desktop dev platform: a Rust daemon for durable state and heavy I/O, a TypeScript frontend for UI and layout, and a Tauri shell that embeds the daemon. This doc ties the pieces together.
 
-## 1. Objetivos de produto
+Read after [panes.md](panes.md), [modes.md](modes.md), [workspaces.md](workspaces.md).
 
-- Permitir execução de tarefas de engenharia via comandos curtos (`cc ...`).
-- Preservar segurança e previsibilidade em operações destrutivas.
-- Integrar com Git de forma assistida e auditável.
-- Evitar dependência de UI externa para operações comuns.
+## Mental model
 
-## 2. Abordagem recomendada
-
-Implementar uma **CLI robusta** (Node.js ou Python), com wrappers para ferramentas existentes.
-
-### Porque não apenas scripts shell?
-Scripts shell funcionam para MVP, mas escalam mal para:
-- Estado de sessão.
-- Logs estruturados.
-- Parsing robusto de flags.
-- Plugins/comandos compostos.
-
-### Stack sugerida
-
-- **CLI**: Node.js + TypeScript (ou Python + Typer).
-- **Config**: arquivo local (`.cc-terminal.yml`) + defaults globais.
-- **Execução**: subprocess com timeout e captura de stdout/stderr.
-- **Persistência leve**:
-  - `~/.cc-terminal/sessions/` (logs por execução)
-  - `~/.cc-terminal/profiles/` (perfis por projeto)
-- **Integrações**:
-  - Git local (`git`)
-  - GitHub CLI (`gh`) para PR
-  - Claude Code via comando/API local conforme disponibilidade
-
-## 3. Camadas do sistema
-
-### 3.1 Interface de comandos
-
-Exemplos:
-- `cc ask "pergunta"`
-- `cc plan "objetivo"`
-- `cc do "objetivo"`
-- `cc review`
-- `cc commit`
-- `cc pr`
-
-Responsabilidades:
-- Validar input do utilizador.
-- Carregar perfil/projeto.
-- Encaminhar para orquestrador.
-
-### 3.2 Orquestrador
-
-Responsável por converter intenção em plano executável:
-1. Coletar contexto do repositório.
-2. Invocar Claude para plano/execução/revisão.
-3. Executar verificações (lint/test/type-check).
-4. Preparar resumo de alterações e próximos passos.
-
-### 3.3 Adaptadores de tooling
-
-- `gitAdapter`: branch status, diff, commit, rebase, push.
-- `testAdapter`: detetar e correr comandos de teste.
-- `prAdapter`: criar PR via `gh`.
-- `aiAdapter`: enviar prompts e receber respostas em formato estruturado.
-
-## 4. Modos de autonomia
-
-Definir três modos claros para reduzir risco:
-
-- `suggest`: apenas recomenda comandos/mudanças.
-- `apply`: altera ficheiros localmente, sem commit automático.
-- `full`: altera + valida + propõe commit/PR.
-
-**Regra**: operações destrutivas (`reset --hard`, delete branch, force push) exigem confirmação explícita.
-
-## 5. Guardrails obrigatórios
-
-- Bloquear operações diretas em `main`/`master` por defeito.
-- Exigir árvore limpa para comandos críticos (`cc commit`, `cc sync`).
-- Executar checks mínimos antes de commit:
-  - lint
-  - testes rápidos
-  - type-check (quando aplicável)
-- Verificar secrets antes de commit (`gitleaks`/`trufflehog` opcional).
-
-## 6. Estrutura de configuração
-
-Exemplo de `.cc-terminal.yml`:
-
-```yaml
-project:
-  default_branch: main
-  protected_branches: [main, master]
-  test_command: npm test -- --runInBand
-  lint_command: npm run lint
-  typecheck_command: npm run typecheck
-ai:
-  mode: apply
-  max_files_per_run: 20
-  require_plan_before_apply: true
-git:
-  branch_prefixes: [feature, fix, chore, refactor]
-  commit_convention: conventional
-  require_issue_reference: false
+```
+┌────────────────────────────── Tauri shell (terminal-app) ──────────────────────────────┐
+│                                                                                         │
+│   ┌──────────────── Rust daemon (terminal-daemon) ──────────────┐   ┌── Frontend ──┐   │
+│   │                                                              │   │ (React/Vite) │   │
+│   │   Axum WS ──► Dispatcher ──► DaemonContext                   │   │              │   │
+│   │                  │           ├── sessions / runs            │   │  App.tsx     │   │
+│   │                  ├──► WorkspaceDispatcher                   │   │   │          │   │
+│   │                  ├──► GitDispatcher                         │   │   ├ AppChrome │   │
+│   │                  └──► PtyManager                            │◄──┤   ├ Sidebar   │   │
+│   │                                                              │ws │   └ PaneRend.│   │
+│   │   Persistence (atomic JSON): sessions/ runs/                 │   │              │   │
+│   │                              worktrees/ terminals/           │   │  State:      │   │
+│   │                                                              │   │   app-store  │   │
+│   │   ClaudeRunner (subprocess), GitEngine (git CLI)             │   │   ws-store   │   │
+│   └──────────────────────────────────────────────────────────────┘   └──────────────┘   │
+│                                                                                         │
+└─────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-## 7. Observabilidade e auditoria
+The daemon owns durable state: workspaces, runs, sessions, PTY metadata, git operations. The frontend owns layout, focus, and presentation. They communicate only over a WebSocket, which enforces a clean separation.
 
-Cada execução deve gerar artefacto com:
-- comando invocado
-- timestamp
-- prompt enviado ao Claude
-- comandos shell executados
-- código de saída
-- ficheiros alterados
+## The three workspace crates
 
-Formato recomendado: JSONL por sessão para facilitar parsing.
+From root `Cargo.toml`:
 
-## 8. Roadmap técnico
+| Crate | Role |
+|-------|------|
+| `terminal-core` | Shared types: protocol (`AppCommand` / `AppEvent`), domain models (`Workspace`, `PaneLayout`, `WorkspaceMode`), `DaemonConfig`, `DaemonMode`. No I/O. |
+| `terminal-daemon` | Library (`lib.rs`) + standalone binary (`main.rs`). Axum WS server, dispatchers, `PtyManager`, git engine, persistence. |
+| `terminal-app` | Tauri v2 native shell. Embeds the daemon in-process via `terminal_daemon::start_server()`. |
 
-### Fase 1 (MVP)
-- CLI base + `cc ask`, `cc plan`, `cc do`.
-- Integração Git simples (`status`, `diff`, `commit` assistido).
+Frontend lives under `frontend/` — React 19 + TypeScript + Vite. It is bundled into `terminal-app` for the native build and also serves standalone for the dockerized web path.
 
-### Fase 2 (Confiabilidade)
-- Modos `suggest/apply/full`.
-- Guardrails de branch + checks automáticos.
+## Daemon
 
-### Fase 3 (Integração GitHub)
-- `cc pr` com template automático.
-- Classificação de risco e checklist de validação.
+### Dispatcher pattern
 
-### Fase 4 (UX avançada)
-- TUI opcional no terminal.
-- Perfis por stack (Node, Python, Go).
+`crates/terminal-daemon/src/dispatcher.rs` is a thin router. It owns no state; it holds a reference to `DaemonContext` and delegates commands to domain-specific dispatchers under `dispatchers/`:
+
+- `dispatchers/workspace_dispatcher.rs` — `CreateWorkspace`, `CloseWorkspace`, `ActivateWorkspace`, `ListWorkspaces`.
+- `dispatchers/git_dispatcher.rs` — extended git ops: `PushBranch`, `PullBranch`, `FetchRemote`, `GetMergeConflicts`, `ResolveConflict`.
+
+Run and session lifecycle live in the main dispatcher for now (they predate the split). If you're adding a new command for an existing domain, add it to that dispatcher; if you're introducing a new domain (e.g. tasks, notifications), add a new file under `dispatchers/`.
+
+### `DaemonContext`
+
+`crates/terminal-daemon/src/daemon_context.rs` is the shared state handle passed to every dispatcher. Fields (`daemon_context.rs:24-39`):
+
+- `config: DaemonConfig`
+- `event_tx: broadcast::Sender<String>` — global event channel
+- `persistence: Arc<Persistence>` — atomic JSON writer
+- `sessions: Arc<Mutex<HashMap<Uuid, Session>>>`
+- `active_runs: Arc<Mutex<HashMap<Uuid, ActiveRun>>>`
+- `concurrency: Arc<Mutex<HashMap<PathBuf, Uuid>>>` — one run per project root
+- `runner: Arc<ClaudeRunner>`
+- `workspaces: Arc<Mutex<HashMap<Uuid, Workspace>>>`
+- `active_workspace_id: Arc<Mutex<Option<Uuid>>>`
+- `workspace_channels: Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>`
+
+Two channels exist: the global `event_tx` for lifecycle events, and per-workspace channels for workspace-scoped output (runs, PTY, git refreshes). `broadcast_workspace(workspace_id, event)` writes to the right one with a fallback to global. See [workspaces.md](workspaces.md#workspace-scoped-event-routing-m1-05).
+
+### Runtime modes
+
+`DaemonMode` (in `terminal-core::config`):
+
+- `Standalone` — writes port and token to `~/.terminal-daemon/` on start. Used by CLI, Docker, and the legacy web build. Persists workspaces and runs to disk.
+- `Embedded` — in-memory only; no file writes. Used by the Tauri app so uninstall leaves no state behind.
+
+### PTY
+
+`crates/terminal-daemon/src/pty/manager.rs` owns terminal sessions. The current implementation uses `openpty` for real PTY allocation (commit `936cc4c`). Each session has a workspace id, a pane id, a shell path, and a cwd — persisted into `TerminalSessionMeta` under `terminals/` so M4-06 can offer restore on daemon restart (see [workspaces.md](workspaces.md#crash-recovery)).
+
+### Git
+
+Pure CLI via `tokio::process::Command`. No libgit2. Rationale: simpler builds, exact git behavior, easier to debug. Basic ops (status, stage, commit, checkout) live in `git_engine.rs`. Extended ops (push/pull/fetch/conflicts) live in `dispatchers/git_dispatcher.rs`.
+
+## Frontend
+
+### State layers
+
+Two top-level stores, imported from `frontend/src/state/`:
+
+- `app-store.ts` — global, cross-workspace state. Connection status, session list, workspace list, active workspace id, command-palette open flag.
+- `workspace-store.ts` — per-workspace state. AI run state, output lines, runs list, selected run, sidebar view, git snapshots, merge conflicts, terminal session summaries, diff panel.
+
+Rule: if two active workspaces need different values, it belongs in `WorkspaceStore`. Otherwise, `AppStore`.
+
+### Service layer
+
+`frontend/src/core/`:
+
+- `commands/commandBus.ts` — UI code calls `commandBus.send(...)`; never touches the WebSocket directly.
+- `events/eventRouter.ts` — incoming daemon events are routed to the app store or the correct workspace store.
+- `services/*.ts` — domain verbs: `sessionService`, `runService`, `gitService`, `workspaceService`, `terminalService`, `contextSwitchService`. Each exposes a small API that composes commandBus calls.
+
+This layer is what shields UI code from protocol churn. If you're adding a feature, put the wire logic in a service and expose a hook or callback to the component.
+
+### Three registries
+
+The frontend has exactly three runtime registries. Everything else composes through them.
+
+| Registry                               | Key             | Value                | Populated by                          |
+|----------------------------------------|------------------|----------------------|----------------------------------------|
+| `frontend/src/panes/registry.ts`       | `PaneKind`      | React component       | side-effect imports in `App.tsx:29-37` |
+| `frontend/src/modes/registry.ts`       | `WorkspaceMode` | `ModeDefinition`     | `frontend/src/modes/definitions.ts`    |
+| `frontend/src/core/keybindings.ts`     | `id: string`    | `KeyBinding`          | feature-local `registerBinding` calls  |
+
+There is no "layout registry" — layouts are values (`PaneLayout`), not registered kinds.
+
+### Rendering path
+
+`App.tsx` wires providers and renders top-level chrome. The main pane area is `PaneRenderer` (`frontend/src/panes/PaneRenderer.tsx`):
+
+1. Receives the active workspace's `PaneLayout`.
+2. Walks the tree, computes absolute positions for every `Single` leaf.
+3. For each leaf, looks up the component in the pane registry and renders it.
+4. Draws split-seam drag handles between pairs of children.
+
+Panes themselves are "dumb" renderers — they read from the workspace store and render their data. Commands go through services, not directly into the pane.
+
+## Protocol
+
+`crates/terminal-core/src/protocol/v1.rs` defines two flat enums, both tagged with `#[serde(tag = "type")]`:
+
+- `AppCommand` — what the client asks for (e.g. `StartRun`, `CreateWorkspace`, `CreateTerminalSession`, `PushBranch`).
+- `AppEvent` — what the daemon reports (e.g. `RunStarted`, `WorkspaceCreated`, `OutputChunk`, `AuthSuccess`).
+
+Every new variant ships with a roundtrip test in the same file's `#[cfg(test)] mod tests` block.
+
+First WS message after connect must be `Auth { token }` within 10 s, otherwise the daemon drops the connection.
+
+## Mode vs pane vs feature
+
+Decision framework for where to put new work:
+
+- **Mode** — if it deserves its own launch shortcut and a distinctive default layout. Examples: Git, Terminal, Browser.
+- **Pane** — if it's a self-contained UI surface that displays or edits one kind of thing. Examples: `GitStatusPane`, `TerminalPane`, `BrowserPane`, `FileViewerPane`, `MergeConflictPane`.
+- **Feature** — everything else: syntax highlighting inside an existing pane, a new shortcut, a new git command, a new command-palette entry, a theme. Features live close to the pane or service they extend, not in their own directory at the top of `panes/`.
+
+Examples:
+
+- A diff viewer is a **pane**. A keyboard shortcut for "next hunk" inside it is a **feature**.
+- Ripgrep search is a **pane**. "Search current repo" from the command palette is a **feature** that opens the search pane.
+- SSH terminals are not a mode — they are a **feature** of the Terminal pane. The SSH-specific chrome lives in `SshConnectDialog.tsx`.
+
+## Testing & building
+
+From `CLAUDE.md`: build Rust inside Docker, build frontend on host.
+
+```bash
+docker compose run --rm test
+docker compose run --rm test cargo check -p terminal-app
+cd frontend && npm run build
+```
+
+MSRV is Rust 1.88 (required by the `time` crate). Dockerfiles pin `rust:1.88-slim`.
+
+## Related
+
+- [panes.md](panes.md)
+- [modes.md](modes.md)
+- [workspaces.md](workspaces.md)
+- [keybindings.md](keybindings.md)
+- [ux-conventions.md](ux-conventions.md)
+- [naming-conventions.md](naming-conventions.md)

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,0 +1,108 @@
+# Keybindings
+
+The keybinding layer makes terminal panes usable without trapping the user. Shortcuts are scoped so shell input (`Ctrl+C`, arrows, `Ctrl+D`) goes to the active terminal while app-level actions stay reachable.
+
+See [naming-conventions.md](naming-conventions.md) for shortcut ID naming.
+
+## Three scopes
+
+`frontend/src/core/keybindings.ts:3` defines `KeyBindingScope`:
+
+```ts
+export type KeyBindingScope = 'app' | 'pane';
+```
+
+| Scope  | Fires when focus is...          | Example                              |
+|--------|----------------------------------|--------------------------------------|
+| `app`  | **not** inside a terminal pane   | `Ctrl+K` (command palette), `Ctrl+B` (sidebar), `Ctrl+1`..`Ctrl+4` (mode switch) |
+| `pane` | inside a terminal pane           | `Ctrl+Shift+|` split-right, `Ctrl+Shift+_` split-down |
+
+There is no `layout` scope. The previous design doc mentioned one, but it was consolidated into `app`. All layout-affecting shortcuts are app-scoped because they must fire regardless of which pane has focus.
+
+## Resolution
+
+`installGlobalKeybindings()` installs a single `window.keydown` listener (`keybindings.ts:39-58`). On each event:
+
+1. Detect whether the event target is inside a terminal pane — it walks up the DOM looking for `[data-pane-kind="terminal"]`.
+2. Skip `'pane'`-scoped bindings when the target is not inside a terminal.
+3. Skip `'app'`-scoped bindings when the target **is** inside a terminal (so shell input passes through).
+4. Match `ctrl / shift / alt + key` literally against each registered binding's `keys` field. First match wins.
+5. If a binding matches, `preventDefault()` and fire `binding.action()`.
+
+There is no stacking order beyond registration order. In practice, only `app` and `pane` bindings exist today and they are disjoint.
+
+## Shortcut map
+
+User-configurable defaults live in `frontend/src/core/shortcutMap.ts`:
+
+```ts
+const DEFAULTS: Record<string, string> = {
+  'pane:split-right': 'Ctrl+Shift+|',
+  'pane:split-down':  'Ctrl+Shift+_',
+  'layout:terminal':  'Ctrl+Alt+1',
+  'layout:ai':        'Ctrl+Alt+2',
+  'layout:git':       'Ctrl+Alt+3',
+  'layout:browser':   'Ctrl+Alt+4',
+  'sidebar:toggle':   'Ctrl+B',
+  'sidebar:explorer': 'Ctrl+Shift+E',
+  'sidebar:changes':  'Ctrl+Shift+G',
+  'sidebar:git':      'Ctrl+Shift+H',
+  'git:refresh':      'Ctrl+Shift+R',
+  'git:push':         '',
+  'git:pull':         '',
+  'git:fetch':        '',
+  'workspace:list':   '',
+};
+```
+
+User overrides persist to `localStorage` under the key `terminal:shortcuts`. Empty string means "unbound" (surfaces in command palette without a visible shortcut).
+
+Read with `getShortcut(id)`, write with `setShortcut(id, combo)`, reset with `resetShortcuts()`. The command palette (`frontend/src/components/CommandPalette.tsx`) reads directly from this map.
+
+## Reserved shortcuts
+
+Reserved combos that **must not** be bound for anything else:
+
+| Combo          | Action                           | Why reserved |
+|----------------|----------------------------------|--------------|
+| `Ctrl+C`       | Copy / shell SIGINT             | Never bind app-level. Forwarded to pane in terminal context. |
+| `Ctrl+D`       | Shell EOF                        | Same. |
+| `Ctrl+Z`       | Shell suspend                    | Same. |
+| Arrow keys     | Shell history / cursor           | Never bind app-level. |
+| `Ctrl+1`..`Ctrl+4` | Activate mode shortcut       | Reserved for mode switching (see `ModeDefinition.shortcut` in [modes.md](modes.md)). |
+| `Ctrl+K`       | Command palette                  | Standard platform shortcut; don't reuse. |
+| `Ctrl+B`       | Toggle sidebar                   | See `shortcutMap.ts` default. |
+| `Ctrl+W`       | Close pane (**app-intercepted**) | Browser / Tauri default is close-window. Must be captured at `installGlobalKeybindings` before the platform sees it. |
+
+`Ctrl+W` is the common footgun: without app-level interception it will close the Tauri window or browser tab. The app handler calls `preventDefault()` before the platform reacts.
+
+## Adding a new shortcut
+
+1. **Pick an ID** — `domain:kebab-action`. Check `DEFAULTS` in `shortcutMap.ts` for collisions and the Reserved table above.
+2. **Add to `DEFAULTS`** — include the default combo (or `''` if unbound by default).
+3. **Register the binding** — in the component or service that owns the action, call `registerBinding({ id, keys: getShortcut('<id>'), scope: 'app', description, action })`. Unregister on teardown (`unregisterBinding(id)`).
+4. **Command palette entry** — if the action should be discoverable, add a command entry that references the shortcut ID. The palette resolves the displayed combo via `getShortcut(id)`.
+5. **Test on a terminal pane** — focus a terminal, press the combo, confirm it fires (app scope) or is forwarded to the shell (pane scope).
+
+## How terminal panes capture input
+
+`TerminalPane` (`frontend/src/panes/terminal/TerminalPane.tsx`) mounts xterm.js and does **not** register any bindings. Its root element sets `data-pane-kind="terminal"`. That attribute is the signal `installGlobalKeybindings` uses to forward events to xterm.
+
+When a user focuses a terminal and types `Ctrl+C`:
+
+1. DOM event lands on the xterm container.
+2. Global listener sees `data-pane-kind="terminal"` on the target chain.
+3. Any registered `'app'`-scope binding is skipped.
+4. Default xterm handling runs, sends `\x03` to the PTY.
+
+`'pane'`-scope bindings (like split shortcuts) still fire — those are the only way to trigger UI actions from inside a terminal pane today.
+
+## Changing scope of an existing shortcut
+
+If a shortcut needs to be moved from `'app'` to `'pane'` (or vice versa), you must rebind it — unregister with the old scope and register with the new one. There's no mutation helper. Expect a follow-up issue if users report friction here.
+
+## Related
+
+- [ux-conventions.md](ux-conventions.md) — focus model, which informs scope resolution
+- [panes.md](panes.md) — the `data-pane-kind` attribute that gates terminal forwarding
+- [modes.md](modes.md) — mode-activation shortcuts (`Ctrl+1`..`Ctrl+4`)

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,94 @@
+# Modes
+
+A mode is a named workspace preset: icon, label, default pane layout, and a launch shortcut. Modes never change behavior at runtime — they only decide the starting layout. After creation, a workspace is freely rearrangeable.
+
+See [naming-conventions.md](naming-conventions.md) and [panes.md](panes.md) first.
+
+## `ModeDefinition`
+
+`frontend/src/modes/types.ts`:
+
+```ts
+export interface ModeDefinition {
+  id: WorkspaceMode;              // 'AiSession' | 'Terminal' | 'Git' | 'Browser'
+  label: string;                  // Human-readable display name
+  icon: string;                   // Single emoji or glyph (e.g. '🤖', '>_', '⎇', '◎')
+  description: string;            // One-sentence description, surfaces in mode picker
+  defaultLayout: () => PaneLayout; // Fresh layout each time (function, not value)
+  shortcut?: string;              // Optional keybinding to create a workspace in this mode
+}
+```
+
+Every field must be populated — none are optional except `shortcut`.
+
+### Field semantics
+
+- **`id`** — must match the `WorkspaceMode` enum in `crates/terminal-core/src/models.rs:8-15`. Adding a new mode requires a Rust change first (see checklist below).
+- **`label`** — shown in the workspace switcher and mode picker. Keep under 16 characters.
+- **`icon`** — single visual character. Do **not** use multi-character sequences or SVG strings. `tokens.css` does not currently ship SVG inline helpers.
+- **`description`** — one sentence, no trailing period, used for mode-picker tooltips.
+- **`defaultLayout`** — **a function** that returns a fresh `PaneLayout` on every call. Returning a shared literal will share references across workspaces and cause weird state bleed. Always call fresh.
+- **`shortcut`** — human-readable combo like `'Ctrl+1'`. Resolved through the keybinding layer (see [keybindings.md](keybindings.md)).
+
+## Registry
+
+`frontend/src/modes/registry.ts`:
+
+```ts
+export function registerMode(def: ModeDefinition): void;
+export function getMode(id: WorkspaceMode): ModeDefinition | null;
+export function listModes(): ModeDefinition[];
+```
+
+Modes are registered by importing `frontend/src/modes/definitions.ts`, which runs `registerMode(...)` for every built-in mode at import time. `frontend/src/App.tsx:38` imports this module for side effects.
+
+## Built-in modes
+
+From `frontend/src/modes/definitions.ts`:
+
+| id          | icon | shortcut   | default layout |
+|-------------|------|-----------|----------------|
+| `AiSession` | 🤖   | `Ctrl+1` | `Single(AiRun)` |
+| `Terminal`  | `>_` | `Ctrl+2` | `Single(Terminal)` |
+| `Git`       | `⎇`  | `Ctrl+3` | `Split(Horizontal, 0.4, GitStatus, GitHistory)` |
+| `Browser`   | `◎`  | `Ctrl+4` | `Single(Browser)` |
+
+## Creating a workspace in a mode
+
+`frontend/src/core/services/workspaceService.ts` ultimately sends `AppCommand::CreateWorkspace { name, root_path, mode }` to the daemon. The daemon calls the corresponding `PaneLayout::default_<mode>()` helper (e.g. `default_git()`, `crates/terminal-core/src/models.rs:111-126`) to fill in the initial layout before persisting the workspace.
+
+The frontend and backend both carry a default-layout function per mode. They must agree: if you change the frontend `defaultLayout()`, update the Rust `default_<mode>()` too.
+
+## Switching modes on an existing workspace
+
+`frontend/src/core/services/contextSwitchService.ts` exposes `switchMode(workspaceId, targetMode)`. It:
+
+1. Preserves `root_path` and `linked_session_id`.
+2. Calls the target mode's `defaultLayout()` to build a fresh layout.
+3. Dispatches a workspace update that replaces the mode and layout.
+
+Switching does **not** migrate pane contents. If the user had three terminals open and switches to Git mode, the terminals are discarded. Prompt before switching in destructive cases.
+
+## Adding a new mode
+
+1. **Rust enum** — add the variant to `WorkspaceMode` in `crates/terminal-core/src/models.rs`. Update the `workspace_mode_all_variants_serialize` test.
+2. **Rust default layout** — add `PaneLayout::default_<mode>()` to the same file, alongside the existing `default_ai_session` / `default_terminal` / `default_git` helpers.
+3. **Frontend `WorkspaceMode` union** — add the literal to `frontend/src/domain/workspace/types.ts`.
+4. **`ModeDefinition`** — add a `registerMode({ id, label, icon, description, defaultLayout, shortcut })` block to `frontend/src/modes/definitions.ts`. The `defaultLayout` must return the same structure as the Rust `default_<mode>()`.
+5. **Shortcut** — pick a free `Ctrl+N` (or other combo). Check `frontend/src/core/shortcutMap.ts` for collisions. See [keybindings.md](keybindings.md).
+6. **Mode picker copy** — double-check the description renders sensibly in `WorkspaceSwitcher.tsx` (the picker uses `listModes()` directly, so adding the entry is enough).
+7. **Protocol roundtrip test** — add a serialization test for the new `WorkspaceMode` variant in `crates/terminal-core/src/protocol/v1.rs`.
+
+No frontend registry file needs editing — `definitions.ts` is the single mode registration point.
+
+## Anti-patterns
+
+- **Do not branch on mode in panes.** A pane should render the same regardless of which mode the containing workspace is in. Modes are layout presets, not behavioral switches.
+- **Do not persist a mode's layout shape separately from the workspace.** The layout lives in `Workspace.layout`; the mode id is just metadata for the chrome badge and future "re-open in this mode" operations.
+- **Do not add mode-specific CSS classes** (`.mode-git`, `.mode-terminal`). Style panes by kind, not by mode.
+
+## Related
+
+- [panes.md](panes.md) — the pane kinds available for `defaultLayout`
+- [workspaces.md](workspaces.md) — how modes surface at workspace creation
+- [architecture.md](architecture.md) — the three-registry pattern (modes, panes, layouts)

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -1,0 +1,107 @@
+# Naming Conventions
+
+Canonical names for every layer of the platform. Other docs reference these rules.
+
+## Files and directories
+
+| Where | Convention | Example |
+|-------|------------|---------|
+| Frontend dirs | `kebab-case` | `frontend/src/panes/git-status/`, `frontend/src/core/services/` |
+| React components | `PascalCase.tsx` | `AppChrome.tsx`, `GitStatusPane.tsx` |
+| TS modules | `camelCase.ts` | `commandBus.ts`, `shortcutMap.ts` |
+| Domain types file | `types.ts` under a domain folder | `frontend/src/domain/pane/types.ts` |
+| Rust modules | `snake_case.rs` | `daemon_context.rs`, `git_engine.rs` |
+| Rust dirs | `snake_case/` with `mod.rs` | `crates/terminal-daemon/src/dispatchers/mod.rs` |
+
+Co-located tests use `.test.tsx` (frontend) or a `#[cfg(test)] mod tests` block at the bottom of the module (Rust).
+
+## TypeScript type names
+
+| Kind | Convention | Example |
+|------|------------|---------|
+| Interfaces / types | `PascalCase` | `ModeDefinition`, `PaneDefinition`, `WorkspaceStore` |
+| Discriminated-union variants | `PascalCase` tag | `{ type: 'SET_CONNECTION_STATUS' }` |
+| String-literal type values | `PascalCase` | `PaneKind = 'AiRun' \| 'Terminal' \| ...` |
+| Enums and union members that mirror Rust enums | exact match to Rust variant | `WorkspaceMode = 'AiSession' \| 'Terminal' \| 'Git' \| 'Browser'` |
+| React props interfaces | `<ComponentName>Props` | `PaneProps`, `PaneHeaderProps` |
+| Hook names | `useXxx` | `useWebSocket`, `useBrowserNavigation` |
+| Event action types | `UPPER_SNAKE_CASE` inside reducer tags | `'SET_SESSIONS'`, `'TOGGLE_COMMAND_PALETTE'` |
+
+## Rust type names
+
+Follow Rust convention:
+
+| Kind | Convention | Example |
+|------|------------|---------|
+| Structs, enums, traits | `PascalCase` | `Workspace`, `PaneLayout`, `DaemonContext`, `MergeConflictFile` |
+| Enum variants | `PascalCase` | `WorkspaceMode::AiSession`, `PaneKind::GitStatus` |
+| Functions, methods, modules, fields | `snake_case` | `broadcast_workspace`, `workspace_channels`, `load_session` |
+| Constants | `SCREAMING_SNAKE_CASE` | `DEFAULTS`, `MAX_OUTPUT_LINES` |
+| Error types | `<Domain>Error` ending | `PersistenceError` |
+
+## Protocol naming (wire format)
+
+Protocol lives in `crates/terminal-core/src/protocol/v1.rs`. It is shared between Rust daemon and TypeScript frontend; names must match exactly on both sides.
+
+| Kind | Convention | Example |
+|------|------------|---------|
+| Command variants (`AppCommand`) | `PascalCase` verb-first | `StartRun`, `CreateWorkspace`, `PushBranch`, `GetRepoStatus` |
+| Event variants (`AppEvent`) | `PascalCase` noun- or past-tense | `WorkspaceCreated`, `RunStarted`, `OutputChunk`, `AuthSuccess` |
+| Struct field names (in JSON) | `snake_case` | `workspace_id`, `last_active_at`, `linked_session_id` |
+| Type tag (Serde) | `{ "type": "VariantName", ... }` | `#[serde(tag = "type")]` on enums |
+
+Rule of thumb: commands are **what the client asks for**, events are **what the daemon reports happened**.
+
+## IDs
+
+| What | Format | Example |
+|------|--------|---------|
+| Workspace ID | UUID v4 | `workspace.id: Uuid` |
+| Run ID | UUID v4 | `run.id: Uuid` |
+| Session ID | UUID v4 | `session.id: Uuid` |
+| Terminal session ID | UUID v4 | `TerminalSessionMeta.session_id` |
+| Pane ID (frontend) | `<kind-lower>-<counter>-<ms>` or layout default | `terminal-3-1712341234567`, `git-status`, `ai-run` |
+| Mode ID | Capitalized literal that matches `WorkspaceMode` | `'AiSession'`, `'Terminal'`, `'Git'`, `'Browser'` |
+
+Mode IDs are **capitalized** (matching `WorkspaceMode` in Rust), not lowercase-kebab. If you see a doc or issue that says "lowercase-kebab," trust the code — it says `'AiSession'`.
+
+## Shortcut IDs
+
+Shortcuts are keyed in `frontend/src/core/shortcutMap.ts` as `domain:action`:
+
+| Domain | Examples |
+|--------|----------|
+| `pane:` | `pane:split-right`, `pane:split-down`, `pane:close`, `pane:focus-next` |
+| `layout:` | `layout:terminal`, `layout:ai`, `layout:git`, `layout:browser` |
+| `sidebar:` | `sidebar:toggle`, `sidebar:explorer`, `sidebar:changes`, `sidebar:git` |
+| `git:` | `git:refresh`, `git:push`, `git:pull`, `git:fetch` |
+| `workspace:` | `workspace:list` |
+
+New shortcut IDs must use `domain:kebab-action` and appear in `shortcutMap.ts`'s `DEFAULTS` object so they surface in the command palette.
+
+## CSS variables
+
+Design tokens live in `frontend/src/styles/tokens.css`. All platform CSS variables use the `--terminal-` prefix:
+
+```css
+--terminal-bg
+--terminal-accent
+--terminal-border
+--terminal-pane-focus
+```
+
+Do not introduce undecorated variable names (`--bg`, `--accent`). Component-local variables may scope under a more specific prefix but must still begin with `--terminal-`.
+
+## Commit messages
+
+From `CLAUDE.md`:
+
+```
+TERMINAL-XXX: <description>
+```
+
+No co-author footer. Prefer one commit per logical step (not per file).
+
+## Branch names
+
+Feature branches follow `claude/<slug>` for Claude Code-driven work (see `claude/implement-open-issues-NLHzf`) or `TERMINAL-XXX/<slug>` for human work (see `TERMINAL-002/docker-all-in-one`).

--- a/docs/panes.md
+++ b/docs/panes.md
@@ -1,0 +1,138 @@
+# Panes
+
+A pane is a single rectangular UI surface inside a workspace (a terminal, a git status view, a browser, etc.). Panes compose into a tree through splits.
+
+See [naming-conventions.md](naming-conventions.md) for file and type naming rules.
+
+## Domain types
+
+Pane types are mirrored between Rust and TypeScript.
+
+**Rust** (`crates/terminal-core/src/models.rs:54-92`):
+
+```rust
+pub enum PaneKind { AiRun, Terminal, GitStatus, GitHistory, FileExplorer, Browser, Diff }
+
+pub struct PaneDefinition {
+    pub id: String,
+    pub kind: PaneKind,
+    pub resource_id: Option<Uuid>,
+}
+
+pub enum PaneLayout {
+    Single(PaneDefinition),
+    Split { direction: SplitDirection, ratio: f32, first: Box<PaneLayout>, second: Box<PaneLayout> },
+}
+```
+
+**TypeScript** (`frontend/src/domain/pane/types.ts`):
+
+```ts
+export type PaneKind =
+  | 'AiRun' | 'Terminal' | 'GitStatus' | 'GitHistory'
+  | 'FileExplorer' | 'Browser' | 'Diff'
+  | 'FileViewer' | 'Search' | 'Empty';
+
+export interface PaneDefinition {
+  id: string;
+  kind: PaneKind;
+  resource_id: string | null;
+  label?: string;
+}
+
+export type PaneLayout =
+  | { Single: PaneDefinition }
+  | { Split: { direction: SplitDirection; ratio: number; first: PaneLayout; second: PaneLayout } };
+```
+
+The TypeScript union includes extra frontend-only kinds (`FileViewer`, `Search`, `Empty`). These render without a Rust-side resource handle.
+
+## Pane registry
+
+`frontend/src/panes/registry.ts` is the single source of truth for kind → component mapping:
+
+```ts
+export function registerPane(kind: PaneKind, component: PaneComponent): void;
+export function getPane(kind: PaneKind): PaneComponent | null;
+```
+
+Each pane module calls `registerPane` at import time. `frontend/src/App.tsx:29-37` imports every pane module for side effects:
+
+```ts
+import './panes/terminal/TerminalPane';
+import './panes/ai-run/AiRunPane';
+import './panes/git/GitStatusPane';
+// ...
+```
+
+Registration failure is silent — forget the side-effect import and `PaneRenderer` will render a placeholder for that kind.
+
+## Pane props
+
+`frontend/src/panes/registry.ts`:
+
+```ts
+export interface PaneProps {
+  pane: PaneDefinition;
+  workspaceId: string;
+  focused: boolean;
+}
+```
+
+The renderer passes these three props. Panes pull their own state from the workspace store via hooks.
+
+## Lifecycle
+
+1. **Mount** — `PaneRenderer` walks the workspace layout tree, instantiates the component from the registry, passes `pane`/`workspaceId`/`focused`.
+2. **State subscription** — the pane subscribes to its slice of `WorkspaceStore` (see [workspaces.md](workspaces.md)) via hooks.
+3. **Render** — the pane draws inside a fixed-size wrapper positioned absolutely by `PaneRenderer`. No layout calculation belongs inside the pane.
+4. **Serialize** — panes are persisted as `PaneDefinition` only: `{ id, kind, resource_id, label? }`. Transient scroll position, input text, selection, etc. are **not** persisted.
+5. **Hydrate** — on restore, the pane mounts with the same `id` and `resource_id`. The pane re-attaches to daemon resources (PTY session, run, etc.) via `resource_id`.
+6. **Unmount** — on pane close, the pane's `useEffect` cleanup runs. If the pane owns a daemon resource, it **must** send the corresponding close command (e.g. `CloseTerminalSession`).
+
+## State ownership
+
+Three tiers, in order of precedence:
+
+| Tier | Owner | Example |
+|------|-------|---------|
+| Daemon-pushed | Rust daemon via protocol events | Run state, PTY output, git status snapshots |
+| Workspace-level | `WorkspaceStore` (`frontend/src/state/workspace-store.ts`) | Run list, output lines, selected run, diff panel, merge conflicts |
+| Pane-local | `useState` inside the component | Hovered button, input draft, pane header edit mode |
+
+Rule: if two panes of the same kind would want to share it, it belongs in `WorkspaceStore`. If it's throwaway UI state, keep it local.
+
+## The `Empty` pane
+
+`PaneKind::Empty` exists only in the frontend (`frontend/src/panes/empty/EmptyPane.tsx`). It is the default content after a split so the user can pick the target kind. Do not persist `Empty` panes to the daemon layout — they are replaced in place when the user chooses a kind.
+
+## Adding a new pane type
+
+Concrete checklist. The goal is that a new pane is visible in about 6 file touches.
+
+1. **Rust `PaneKind`** — add the variant to `crates/terminal-core/src/models.rs` `PaneKind` enum.
+2. **Serialization test** — add a roundtrip test in the same `#[cfg(test)] mod tests` block (see the existing `pane_layout_default_git` test as a template).
+3. **Frontend `PaneKind`** — add the literal to `frontend/src/domain/pane/types.ts` union and to the `PANE_LABELS` table in `frontend/src/panes/PaneRenderer.tsx:9`.
+4. **Component** — create `frontend/src/panes/<kind>/XxxPane.tsx`. Accept `PaneProps`. At the bottom: `registerPane('<Kind>', XxxPane);`.
+5. **Side-effect import** — add `import './panes/<kind>/XxxPane';` to `frontend/src/App.tsx:29-37`.
+6. **(Optional) Mode default** — if the pane is the primary content of a mode, reference it from a `ModeDefinition.defaultLayout()` in `frontend/src/modes/definitions.ts`. See [modes.md](modes.md).
+7. **(Optional) Command palette entry** — register a `pane:open-<kind>` command in `frontend/src/core/shortcutMap.ts` so users can open the pane without menus.
+
+Do **not** create a README inside `frontend/src/panes/<kind>/`. The checklist above is the authoritative onboarding doc.
+
+## Pane chrome
+
+`PaneRenderer` renders a consistent header on every pane (see `frontend/src/panes/PaneRenderer.tsx:22-60`):
+
+- icon + label (from `PANE_LABELS`, overridable via `PaneDefinition.label`)
+- focus ring (`--terminal-pane-focus` CSS variable, applied when `focused: true`)
+- inline split buttons (`Columns2` / `Rows2` icons) and close (`X`) when `canClose`
+- double-click label to rename
+
+Panes should not draw their own outer border or title bar. Let the chrome handle it.
+
+## Related
+
+- [modes.md](modes.md) — which panes a new workspace starts with
+- [workspaces.md](workspaces.md) — how pane state is persisted
+- [keybindings.md](keybindings.md) — how focus moves between panes

--- a/docs/ux-conventions.md
+++ b/docs/ux-conventions.md
@@ -1,0 +1,105 @@
+# UX Conventions
+
+Rules that keep the platform coherent across modes, panes, and contributors. These are constraints, not suggestions.
+
+## App chrome (always visible)
+
+`frontend/src/components/AppChrome.tsx` is drawn above the pane tree in every mode. It shows:
+
+- workspace title (with inline rename)
+- mode badge (icon from `ModeDefinition.icon`, label from `.label`)
+- connection status indicator (green connected, amber authenticating, red disconnected)
+- workspace switcher entry point
+- global actions button (opens command palette)
+
+`AppChrome` is single-row, fixed height (see `tokens.css` `--terminal-chrome-height`). It never scrolls, never collapses. If you're adding global UI, either put it in `AppChrome` or expose it through the command palette — do not add a new top-level strip.
+
+The `StatusBar` (`frontend/src/components/StatusBar.tsx`) sits at the bottom and surfaces contextual info (branch, agent status, active-run line count). Clickable regions navigate or open panels.
+
+## Pane chrome
+
+`PaneRenderer` (`frontend/src/panes/PaneRenderer.tsx`) wraps every pane with consistent chrome:
+
+- header bar: icon, label, split buttons, close button
+- focus ring: `--terminal-pane-focus` border on the focused pane
+- inline rename: double-click the label
+- no pane draws its own outer border or title bar
+
+Consistency rule: if a pane needs a header action (like "refresh"), put it **inside** the pane body's top row — not in the chrome header. The chrome is for layout operations only.
+
+## Focus model
+
+- **One pane is focused at any time.** The focused pane has the `--terminal-pane-focus` ring.
+- **Click-to-focus.** Clicking anywhere inside a pane focuses it. No hover focus, no keyboard-only focus.
+- **Keyboard movement.** `Ctrl+Alt+Arrow` moves focus directionally (see `shortcutMap.ts`).
+- **New panes steal focus.** When the user splits a pane, the new pane (typically `Empty`) becomes focused.
+- **Terminal panes hold keyboard input.** See [keybindings.md](keybindings.md) — app-scope shortcuts are skipped while a terminal is focused.
+
+Modals (command palette, dirty-warning modal, SSH connect dialog) trap focus until dismissed.
+
+## Resize behavior
+
+- Split ratios persist on the `PaneLayout::Split` node (`ratio: f32` in Rust, `ratio: number` in TS).
+- Drag handles are inline on the split boundary (no dedicated resize affordance separate from the split seam).
+- Minimum pane size: **120 px** per axis. Drags below that clamp at the minimum. If a pane would be smaller than 120 px, the drag is ignored — do not introduce scroll-to-see behavior.
+- Double-clicking a split seam resets the ratio to 0.5.
+- Ratios are persisted (debounced) to the workspace — see [workspaces.md](workspaces.md).
+
+## Empty, loading, error states
+
+Every pane has to handle all three. Conventions:
+
+- **Empty state** — a centered one-line message and, where relevant, a single primary action. `frontend/src/components/WelcomeScreen.tsx` is the canonical example. No illustrations, no multi-paragraph copy.
+- **Loading state** — inline spinner next to the element loading, not a full-pane overlay. Full-pane overlays block the user from doing other things and are reserved for destructive confirmations.
+- **Error state** — red accent (`--terminal-error`) on the affected element with a plain-language one-liner. Include a recovery action (retry, dismiss) where possible. No stack traces in the UI; log to the daemon instead.
+
+`ErrorBoundary` (`frontend/src/components/ErrorBoundary.tsx`) catches unhandled render errors and shows a full-pane fallback with a reload button. Panes do not need their own error boundaries — the parent one suffices.
+
+## Destructive actions
+
+- Require explicit confirmation: close workspace (if it owns live runs or PTY sessions), force-push, reset --hard, delete branch.
+- Non-destructive actions (stage, commit, create branch) fire immediately, with a reversible undo via git itself.
+- `DirtyWarningModal` (`frontend/src/components/DirtyWarningModal.tsx`) is the pattern for dirty-state confirmations. Reuse it; don't invent new confirm dialogs.
+
+## Color, density, motion
+
+- **Theme** — driven by `frontend/src/styles/themes.ts` and `tokens.css`. Every visible color must resolve to a `--terminal-*` CSS variable. No hardcoded hex in component styles.
+- **Density** — compact but readable. Default line-height 1.4, default font size 13 px. No spacer `<div>`s taller than 24 px.
+- **Motion** — animations under 200 ms, use `--terminal-ease`. No bouncing, no oversized transitions. `animations.css` holds the shared keyframes.
+- **Icons** — `lucide-react` only. Don't mix icon libraries.
+
+## Text
+
+- Use plain verbs and nouns. "Stage file", not "Click here to stage".
+- Capitalize only the first word and proper nouns in buttons and headers ("Create workspace", not "Create Workspace").
+- Errors: say what happened and, if possible, the next action. Not "Something went wrong".
+- No trailing periods in buttons, tooltips, or headers. Full sentences in modals, prose in docs.
+
+## Toasts
+
+`ToastContainer` (`frontend/src/components/ToastContainer.tsx`) handles transient feedback (copied to clipboard, branch switched, etc.). Rules:
+
+- Toasts are informational, never blocking.
+- Auto-dismiss after 3 seconds unless they carry an action.
+- No more than two concurrent toasts. Newer replaces oldest.
+- Errors prefer inline messaging over toasts — toasts are easy to miss.
+
+## Discoverability
+
+- Every action worth exposing lives in the command palette. If the palette doesn't know about it, the keybinding will feel arbitrary.
+- Every shortcut is visible — either in a tooltip, `ShortcutCheatsheet.tsx`, or as the trailing label in the palette.
+- The command palette is opened with `Ctrl+K`. This is reserved (see [keybindings.md](keybindings.md)).
+
+## Anti-patterns
+
+- Don't build mode-specific chrome. If it should appear in Git mode, think about whether it should just appear in the `GitStatus` pane.
+- Don't block with full-screen spinners. Inline spinners.
+- Don't introduce a third sidebar. `ActivityBar` + `SidebarContainer` is the full surface.
+- Don't auto-hide the pane header. Users need the split/close affordances visible.
+- Don't add "undo" UI for non-git actions. Git is the undo surface.
+
+## Related
+
+- [panes.md](panes.md) — what "pane chrome" wraps
+- [keybindings.md](keybindings.md) — focus and input routing
+- [architecture.md](architecture.md) — frontend layering that implements these conventions

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,138 @@
+# Workspaces
+
+A workspace binds a project root directory to a mode, a pane layout, and an optional AI session. It is the top-level unit of user work.
+
+See [modes.md](modes.md) and [panes.md](panes.md) first.
+
+## Domain type
+
+`crates/terminal-core/src/models.rs:17-28`:
+
+```rust
+pub struct Workspace {
+    pub id: Uuid,
+    pub name: String,
+    pub root_path: PathBuf,
+    pub mode: WorkspaceMode,
+    pub layout: PaneLayout,
+    pub linked_session_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub last_active_at: DateTime<Utc>,
+}
+```
+
+`WorkspaceSummary` (same file, `:31-52`) is the wire-friendly projection — same fields minus `layout` and `created_at`. `WorkspaceSummary` is what goes over the wire in list views; the full `Workspace` is fetched only when one is activated.
+
+## Lifecycle
+
+```
+list → create → activate → (use / rearrange) → persist
+                    ↓                          ↓
+                  close ←──────────────────── restore (on daemon start)
+```
+
+### Create
+
+Frontend sends `AppCommand::CreateWorkspace { name, root_path, mode }` (`crates/terminal-core/src/protocol/v1.rs:107-111`). The daemon:
+
+1. Generates a UUID v4.
+2. Calls `PaneLayout::default_<mode>()` to fill the layout.
+3. Writes the workspace to persistence atomically.
+4. Registers a workspace-scoped broadcast channel in `DaemonContext.workspace_channels`.
+5. Broadcasts `AppEvent::WorkspaceCreated { workspace }` on the global channel.
+
+### Activate
+
+`AppCommand::ActivateWorkspace { workspace_id }` marks a workspace as active for the current client. Today this is stored globally in `DaemonContext.active_workspace_id` (single-client simplification; see `crates/terminal-daemon/src/daemon_context.rs:36`). Future multi-client support will scope this per connection.
+
+Activation triggers `AppEvent::WorkspaceActivated { workspace_id }`.
+
+### Use / rearrange
+
+Panes, runs, git operations, and terminal sessions operate inside the active workspace. Every command that belongs to a workspace carries a `workspace_id` field. See `crates/terminal-core/src/protocol/v1.rs` for the full list — `StartRun`, `CreateTerminalSession`, `GetRepoStatus`, etc.
+
+### Close
+
+`AppCommand::CloseWorkspace { workspace_id }` removes the workspace from memory and disk. The daemon tears down its broadcast channel and emits `WorkspaceClosed`. Any child resources (runs, terminal sessions) owned by the workspace are stopped first.
+
+## Persistence model
+
+Workspaces persist to the daemon data dir (see `DaemonMode::Standalone` at `~/.terminal-daemon/`). `crates/terminal-daemon/src/persistence.rs:36-42` creates the following subdirs on startup:
+
+- `sessions/` — AI sessions
+- `runs/` — per-run artifacts
+- `worktrees/` — sandbox worktree metadata
+- `terminals/` — `TerminalSessionMeta` for M4-06 restore
+
+Workspaces are persisted under the same base dir (one JSON per workspace). Writes go through `Persistence::atomic_write`:
+
+```rust
+fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, data)?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+```
+
+Rule: **every write is atomic** (temp file + rename). Never write in place.
+
+### What is saved
+
+Field by field:
+
+- `id`, `name`, `root_path`, `mode`, `created_at` — on create, never rewritten.
+- `layout` — rewritten every time the user splits, closes, resizes, or renames a pane.
+- `linked_session_id` — rewritten when the user links/unlinks an AI session.
+- `last_active_at` — updated on activation and on significant interactions.
+
+Layout writes are debounced client-side — the frontend updates its in-memory store immediately but batches the persistence command (typically ~300 ms) to avoid hammering disk on drag-resize.
+
+### What is not saved
+
+- Pane-local UI state (scroll, input drafts, selection).
+- Terminal output scrollback (PTY output streams, not persisted; reconnect rebuilds from the live shell).
+- Run output (lives in `runs/<id>/output` files, not the workspace JSON).
+
+## Crash recovery
+
+`DaemonMode::Standalone` writes port and token to `~/.terminal-daemon/` on start. On restart the daemon:
+
+1. Re-reads every `*.json` under the workspace dir, deserializes into `Workspace`.
+2. Re-creates the per-workspace `broadcast::Sender<String>` in `DaemonContext.workspace_channels`.
+3. Walks `terminals/` and emits `RestorableTerminalSessions` — the frontend offers to spawn fresh shells in the same cwd (see `crates/terminal-core/src/models.rs:394-399`, `RestorableTerminalSession`).
+4. Walks `runs/` and marks any run still in an active state as `Failed { phase: FailPhase::Cleanup }` (daemon does not resume runs across restart).
+
+`DaemonMode::Embedded` (Tauri app, `terminal_app` crate) uses in-memory-only state — no file writes. Restart means starting from scratch.
+
+## Workspace-scoped event routing (M1-05)
+
+`DaemonContext.workspace_channels` holds a `broadcast::Sender<String>` per workspace. Events that concern a single workspace (run progress, PTY output, git refresh) go through that workspace's channel via `DaemonContext::broadcast_workspace(workspace_id, event)` (`daemon_context.rs:68-80`). If no channel is registered, the event falls back to the global `event_tx`.
+
+Global events (auth, connection heartbeat, workspace list) always use the global channel.
+
+Clients authenticate once and then subscribe to both the global channel and each workspace channel they activate.
+
+## Cross-mode context transfer
+
+`frontend/src/core/services/contextSwitchService.ts` exposes `switchMode(workspaceId, targetMode)`:
+
+- Keeps `root_path` and `linked_session_id` on the existing workspace.
+- Replaces `mode` and `layout` with the target mode's `defaultLayout()`.
+- Persists the update and re-renders.
+
+For "open the same context in a new workspace" (e.g. spin up a Terminal mode window on the same repo) the service spawns a new workspace with the same `root_path` and a different mode, so both workspaces coexist.
+
+## Adding workspace-related state
+
+Global (app-wide): add to `AppStore` in `frontend/src/state/app-store.ts`. Example: connection status, command palette open flag.
+
+Per-workspace: add to `WorkspaceStore` in `frontend/src/state/workspace-store.ts`. Example: sidebar view, open diff panel, merge conflicts.
+
+If the state belongs on disk across restarts, plumb it through `Workspace` (Rust model) and a new protocol command/event pair. Don't put persistence-worthy data in `WorkspaceStore` only — it dies with the tab.
+
+## Related
+
+- [architecture.md](architecture.md) — how workspaces sit between the daemon and the pane tree
+- [panes.md](panes.md) — what `layout` points at
+- [modes.md](modes.md) — where the initial layout comes from


### PR DESCRIPTION
## Summary

Implements #35 (M7-03). Adds seven contributor docs under `docs/` so future changes stay consistent, and updates `CLAUDE.md` to link them. All other 29 open issues (M1–M7) were already merged to `main` — closed with reference comments pointing to the landed code.

## What landed

- `docs/architecture.md` — rewritten to describe the actual platform (daemon dispatcher pattern, three frontend registries, mode/pane/feature decision framework). Replaces the stale Portuguese CLI proposal that previously lived there.
- `docs/modes.md` — `ModeDefinition` contract, built-in modes table, *Adding a new mode* numbered checklist.
- `docs/panes.md` — `PaneDefinition` lifecycle, state ownership tiers, *Adding a new pane type* numbered checklist.
- `docs/workspaces.md` — lifecycle, atomic-JSON persistence, crash recovery, workspace-scoped event routing (M1-05).
- `docs/keybindings.md` — `app` vs `pane` scope, reserved shortcuts table, how terminal panes capture input via `data-pane-kind="terminal"`.
- `docs/ux-conventions.md` — app/pane chrome, focus model, resize rules, empty/loading/error states, anti-patterns.
- `docs/naming-conventions.md` — file, type, protocol, shortcut, and CSS-variable naming. Referenced by every other doc.
- `CLAUDE.md` — added *Architecture & Contributor Docs* section linking to `docs/`. CLAUDE.md stays lean (build/test/conventions).

## Acceptance criteria (from #35)

- [x] Documentation exists in `docs/` at repo root (7 files).
- [x] A new contributor can understand the platform mental model without reverse-engineering code.
- [x] Every *adding a new mode/pane* workflow has a step-by-step checklist.
- [x] `CLAUDE.md` links to the docs.
- [x] Future issue work has an explicit reference point.
- [x] Each doc standalone, under 300 lines (174, 108, 94, 107, 138, 105, 138).

## Issue triage

Before starting this PR, I audited all 30 open issues against `main`. 29 of them were already implemented and merged — each got a comment pointing to the landed code and was closed as completed:

- M1 Foundation: #12, #15, #19, #24, #28
- M2 Panes: #10, #11, #13, #18, #22
- M3 Modes: #14, #16, #17
- M4 Terminal: #20, #21, #23, #26, #27, #38
- M5 Git: #25, #29, #30, #36, #37
- M6 Browser: #31, #32
- M7 Polish: #33, #34
- TERMINAL-005 integration: #40

Only #35 (M7-03) had real work remaining, which is what this PR implements.

## Test plan

- [x] `wc -l docs/*.md` confirms each new doc is well under the 300-line cap
- [x] All cross-doc relative links resolve to files in `docs/`
- [x] `CLAUDE.md` link block renders as valid Markdown and points at real files
- [x] No code paths or file paths referenced in the docs are fabricated — every `frontend/src/...` / `crates/...` / line-number reference was read from the tree before citing

https://claude.ai/code/session_01RSAPPWut6aBiSomfLyatza