### PR TITLE
Fix all haiku-marked issues: critical and major backend/frontend/docs fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Key domain groups:
 - **Git operations**: Pure CLI via `tokio::process::Command`. No libgit2.
 - **Persistence**: Atomic JSON writes (`.tmp` → rename). Crash recovery on startup. Subdirs: `sessions/`, `runs/`, `worktrees/`, `terminals/`.
 - **Error handling**: `Result<T, Box<dyn Error + Send + Sync>>` at boundaries. `thiserror` for typed errors. No `unwrap()` in `start_server()`.
-- **PTY sessions**: Subprocess with piped stdin/stdout. No true PTY (`ioctl(TIOCSWINSZ)`) in current implementation. Linux `/proc/<pid>/cwd` for cwd tracking.
+- **PTY sessions**: Real PTY via openpty(2). Terminal resize via `ioctl(TIOCSWINSZ)`. Linux `/proc/<pid>/cwd` for cwd tracking.
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: help run stop desktop test test-rust test-frontend lint
+
+help:
+	@echo "Terminal Engine — Development Commands"
+	@echo ""
+	@echo "  make run            Start the daemon and frontend in development mode"
+	@echo "  make stop           Stop the daemon"
+	@echo "  make desktop        Build and run the native Tauri desktop app"
+	@echo "  make test           Run all tests (Rust + frontend)"
+	@echo "  make test-rust      Run Rust tests only"
+	@echo "  make test-frontend  Run frontend tests only"
+	@echo "  make lint           Run linters (cargo fmt, clippy, eslint)"
+	@echo ""
+
+run:
+	./run.sh
+
+stop:
+	./run.sh stop
+
+desktop:
+	./release.sh
+
+test: test-rust test-frontend
+
+test-rust:
+	docker compose run --rm --profile test test
+
+test-frontend:
+	cd frontend && npm test -- --run
+
+lint:
+	cargo fmt --check
+	cargo clippy --all-targets --all-features
+	cd frontend && npm run lint

--- a/README.md
+++ b/README.md
@@ -144,6 +144,33 @@ docker compose run --rm frontend npx tsc --noEmit --skipLibCheck
 docker compose run --rm frontend npm run build
 ```
 
+## Configuration
+
+The daemon is configured via environment variables. This table lists all supported options:
+
+| Variable | Default | Scope | Description |
+|----------|---------|-------|-------------|
+| `TERMINAL_HOST` | `127.0.0.1` | Standalone / Native | Address to bind the WebSocket server to |
+| `TERMINAL_PORT` | `0` (random) | Standalone / Native | Port for the WebSocket server (0 = auto-assign) |
+| `TERMINAL_DATA_DIR` | `~/.terminal-daemon/` | Standalone / Native | Directory for persisted data (sessions, runs, worktrees) |
+| `TERMINAL_CLAUDE_BINARY` | `claude` | All | Path to or command for the Claude CLI binary |
+| `RUST_LOG` | `info` | All | Log level (trace, debug, info, warn, error) |
+
+### Examples
+
+```bash
+# Custom port and data directory
+TERMINAL_PORT=3001 TERMINAL_DATA_DIR=/tmp/terminal-data ./run.sh
+
+# Use a specific Claude binary
+TERMINAL_CLAUDE_BINARY=/usr/local/bin/claude cargo run -p terminal-daemon
+
+# Debug logging
+RUST_LOG=debug docker compose up
+```
+
+Note: The embedded Tauri app (native desktop) does not write these files to disk. Only the standalone daemon respects `TERMINAL_DATA_DIR`, `TERMINAL_HOST`, and `TERMINAL_PORT`.
+
 ## Local Development (without Docker)
 
 If you prefer running natively:

--- a/crates/terminal-core/src/protocol/v1.rs
+++ b/crates/terminal-core/src/protocol/v1.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use crate::models::{
     AutonomyLevel, BranchInfo, CommitEntry, DiffStat, DirtyFile, DirtyStatus, FailPhase,
     FileChange, FileStatus, FileTreeEntry, MergeConflictFile, MergeResult, RepoStatusSnapshot,

--- a/crates/terminal-daemon/src/dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatcher.rs
@@ -857,78 +857,76 @@ impl Dispatcher {
             // --- Sidebar commands (Phase 3) ---
 
             AppCommand::ListDirectory { path } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    let full_path = root.join(&path);
-                    match crate::git_engine::list_directory(&full_path).await {
-                        Ok(entries) => {
-                            let _ = reply_tx
-                                .send(AppEvent::DirectoryListing { path, entries })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "LIST_DIR_FAILED".into(),
-                                    message: e.to_string(),
-                                })
-                                .await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let full_path = root.join(&path);
+                match crate::git_engine::list_directory(&full_path).await {
+                    Ok(entries) => {
+                        let _ = reply_tx
+                            .send(AppEvent::DirectoryListing { path, entries })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "LIST_DIR_FAILED".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
 
             AppCommand::GetChangedFiles { mode, run_id } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    let result: std::result::Result<Vec<FileChange>, String> = if mode == "working" {
-                        match crate::git_engine::working_dir_status(&root).await {
-                            Ok(s) => {
-                                let mut files: Vec<FileChange> = s
-                                    .staged
-                                    .into_iter()
-                                    .map(|f| FileChange {
-                                        path: f.path,
-                                        status: f.status,
-                                    })
-                                    .collect();
-                                files.extend(s.unstaged.into_iter().map(|f| FileChange {
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let result: std::result::Result<Vec<FileChange>, String> = if mode == "working" {
+                    match crate::git_engine::working_dir_status(&root).await {
+                        Ok(s) => {
+                            let mut files: Vec<FileChange> = s
+                                .staged
+                                .into_iter()
+                                .map(|f| FileChange {
                                     path: f.path,
                                     status: f.status,
-                                }));
-                                Ok(files)
-                            }
-                            Err(e) => Err(e.to_string()),
+                                })
+                                .collect();
+                            files.extend(s.unstaged.into_iter().map(|f| FileChange {
+                                path: f.path,
+                                status: f.status,
+                            }));
+                            Ok(files)
                         }
-                    } else if let Some(rid) = run_id {
-                        match self.context.persistence.load_worktree_meta(rid) {
-                            Ok(meta) => {
-                                crate::git_engine::changed_files(&root, &meta.base_head, "HEAD")
-                                    .await
-                                    .map_err(|e| e.to_string())
-                            }
-                            Err(e) => Err(format!("worktree meta: {}", e)),
+                        Err(e) => Err(e.to_string()),
+                    }
+                } else if let Some(rid) = run_id {
+                    match self.context.persistence.load_worktree_meta(rid) {
+                        Ok(meta) => {
+                            crate::git_engine::changed_files(&root, &meta.base_head, "HEAD")
+                                .await
+                                .map_err(|e| e.to_string())
                         }
-                    } else {
-                        Ok(vec![])
-                    };
+                        Err(e) => Err(format!("worktree meta: {}", e)),
+                    }
+                } else {
+                    Ok(vec![])
+                };
 
-                    match result {
-                        Ok(files) => {
-                            let _ = reply_tx
-                                .send(AppEvent::ChangedFilesList {
-                                    mode,
-                                    run_id,
-                                    files,
-                                })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "CHANGED_FILES_FAILED".into(),
-                                    message: e,
-                                })
-                                .await;
-                        }
+                match result {
+                    Ok(files) => {
+                        let _ = reply_tx
+                            .send(AppEvent::ChangedFilesList {
+                                mode,
+                                run_id,
+                                files,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "CHANGED_FILES_FAILED".into(),
+                                message: e,
+                            })
+                            .await;
                     }
                 }
             }
@@ -938,90 +936,55 @@ impl Dispatcher {
                 mode,
                 run_id,
             } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    let result: std::result::Result<String, String> = if mode == "working" {
-                        crate::git_engine::working_dir_file_diff(&root, &file_path)
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let result: std::result::Result<String, String> = if mode == "working" {
+                    crate::git_engine::working_dir_file_diff(&root, &file_path)
+                        .await
+                        .map_err(|e| e.to_string())
+                } else if let Some(rid) = run_id {
+                    match self.context.persistence.load_worktree_meta(rid) {
+                        Ok(meta) => crate::git_engine::diff_full(&root, &meta.base_head, "HEAD")
                             .await
-                            .map_err(|e| e.to_string())
-                    } else if let Some(rid) = run_id {
-                        match self.context.persistence.load_worktree_meta(rid) {
-                            Ok(meta) => crate::git_engine::diff_full(&root, &meta.base_head, "HEAD")
-                                .await
-                                .map_err(|e| e.to_string()),
-                            Err(e) => Err(format!("worktree meta: {}", e)),
-                        }
-                    } else {
-                        Ok(String::new())
-                    };
+                            .map_err(|e| e.to_string()),
+                        Err(e) => Err(format!("worktree meta: {}", e)),
+                    }
+                } else {
+                    Ok(String::new())
+                };
 
-                    match result {
-                        Ok(diff) => {
-                            let _ = reply_tx
-                                .send(AppEvent::FileDiffResult {
-                                    file_path,
-                                    diff,
-                                    stat: None,
-                                })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "FILE_DIFF_FAILED".into(),
-                                    message: e,
-                                })
-                                .await;
-                        }
+                match result {
+                    Ok(diff) => {
+                        let _ = reply_tx
+                            .send(AppEvent::FileDiffResult {
+                                file_path,
+                                diff,
+                                stat: None,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "FILE_DIFF_FAILED".into(),
+                                message: e,
+                            })
+                            .await;
                     }
                 }
             }
 
             AppCommand::GetRepoStatus => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::repo_status_snapshot(&root).await {
-                        Ok(status) => {
-                            let _ = reply_tx
-                                .send(AppEvent::RepoStatusResult { status })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "REPO_STATUS_FAILED".into(),
-                                    message: e.to_string(),
-                                })
-                                .await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::repo_status_snapshot(&root).await {
+                    Ok(status) => {
+                        let _ = reply_tx
+                            .send(AppEvent::RepoStatusResult { status })
+                            .await;
                     }
-                }
-            }
-
-            AppCommand::GetCommitHistory { limit } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::commit_history(&root, limit).await {
-                        Ok(commits) => {
-                            let _ = reply_tx
-                                .send(AppEvent::CommitHistoryResult { commits })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "COMMIT_HISTORY_FAILED".into(),
-                                    message: e.to_string(),
-                                })
-                                .await;
-                        }
-                    }
-                }
-            }
-
-            AppCommand::StageFile { path } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    if let Err(e) = crate::git_engine::stage_file(&root, &path).await {
+                    Err(e) => {
                         let _ = reply_tx
                             .send(AppEvent::Error {
-                                code: "STAGE_FAILED".into(),
+                                code: "REPO_STATUS_FAILED".into(),
                                 message: e.to_string(),
                             })
                             .await;
@@ -1029,95 +992,129 @@ impl Dispatcher {
                 }
             }
 
-            AppCommand::UnstageFile { path } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    if let Err(e) = crate::git_engine::unstage_file(&root, &path).await {
+            AppCommand::GetCommitHistory { limit } => {
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::commit_history(&root, limit).await {
+                    Ok(commits) => {
+                        let _ = reply_tx
+                            .send(AppEvent::CommitHistoryResult { commits })
+                            .await;
+                    }
+                    Err(e) => {
                         let _ = reply_tx
                             .send(AppEvent::Error {
-                                    code: "UNSTAGE_FAILED".into(),
-                                    message: e.to_string(),
+                                code: "COMMIT_HISTORY_FAILED".into(),
+                                message: e.to_string(),
                             })
                             .await;
                     }
                 }
             }
 
+            AppCommand::StageFile { path } => {
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                if let Err(e) = crate::git_engine::stage_file(&root, &path).await {
+                    let _ = reply_tx
+                        .send(AppEvent::Error {
+                            code: "STAGE_FAILED".into(),
+                            message: e.to_string(),
+                        })
+                        .await;
+                } else if let Ok(status) = crate::git_engine::repo_status_snapshot(&root).await {
+                    let _ = reply_tx
+                        .send(AppEvent::RepoStatusResult { status })
+                        .await;
+                }
+            }
+
+            AppCommand::UnstageFile { path } => {
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                if let Err(e) = crate::git_engine::unstage_file(&root, &path).await {
+                    let _ = reply_tx
+                        .send(AppEvent::Error {
+                                code: "UNSTAGE_FAILED".into(),
+                                message: e.to_string(),
+                        })
+                        .await;
+                } else if let Ok(status) = crate::git_engine::repo_status_snapshot(&root).await {
+                    let _ = reply_tx
+                        .send(AppEvent::RepoStatusResult { status })
+                        .await;
+                }
+            }
+
             AppCommand::CreateCommit { message } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::create_commit(&root, &message).await {
-                        Ok(hash) => {
-                            let _ = reply_tx
-                                .send(AppEvent::CommitCreated { hash })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "COMMIT_FAILED".into(),
-                                    message: e.to_string(),
-                                })
-                                .await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::create_commit(&root, &message).await {
+                    Ok(hash) => {
+                        let _ = reply_tx
+                            .send(AppEvent::CommitCreated { hash })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "COMMIT_FAILED".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
 
             AppCommand::ListBranches => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::list_branches(&root).await {
-                        Ok((branches, current)) => {
-                            let _ = reply_tx
-                                .send(AppEvent::BranchList { branches, current })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "GIT_ERROR".into(),
-                                    message: e.to_string(),
-                                })
-                                .await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::list_branches(&root).await {
+                    Ok((branches, current)) => {
+                        let _ = reply_tx
+                            .send(AppEvent::BranchList { branches, current })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "GIT_ERROR".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
 
             AppCommand::CheckoutBranch { name } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::checkout_branch(&root, &name).await {
-                        Ok(()) => {
-                            let _ = reply_tx
-                                .send(AppEvent::BranchChanged { name })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "CHECKOUT_FAILED".into(),
-                                    message: e.to_string(),
-                                })
-                                .await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::checkout_branch(&root, &name).await {
+                    Ok(()) => {
+                        let _ = reply_tx
+                            .send(AppEvent::BranchChanged { name })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "CHECKOUT_FAILED".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
 
             AppCommand::CreateBranch { name, from } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::create_branch(&root, &name, from.as_deref()).await {
-                        Ok(()) => {
-                            let _ = reply_tx
-                                .send(AppEvent::BranchChanged { name })
-                                .await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx
-                                .send(AppEvent::Error {
-                                    code: "CREATE_BRANCH_FAILED".into(),
-                                    message: e.to_string(),
-                                })
-                                .await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::create_branch(&root, &name, from.as_deref()).await {
+                    Ok(()) => {
+                        let _ = reply_tx
+                            .send(AppEvent::BranchChanged { name })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "CREATE_BRANCH_FAILED".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
@@ -1175,7 +1172,17 @@ impl Dispatcher {
             }
 
             AppCommand::ResizeTerminal { session_id, cols, rows } => {
-                self.pty_manager.resize(session_id, cols, rows).await;
+                match self.pty_manager.resize(session_id, cols, rows).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "RESIZE_FAILED".into(),
+                                message: e,
+                            })
+                            .await;
+                    }
+                }
             }
 
             AppCommand::ListTerminalSessions { workspace_id } => {
@@ -1185,7 +1192,7 @@ impl Dispatcher {
                     .await;
             }
 
-            AppCommand::RestoreTerminalSession { previous_session_id, workspace_id } => {
+            AppCommand::RestoreTerminalSession { previous_session_id, workspace_id: _ } => {
                 // Placeholder: PTY sessions can't persist across daemon restarts in pipe mode.
                 // Full persistence handled in M4-06.
                 let _ = reply_tx
@@ -1197,12 +1204,24 @@ impl Dispatcher {
             }
 
             AppCommand::ListRestoredTerminalSessions { workspace_id } => {
-                let _ = reply_tx
-                    .send(AppEvent::RestorableTerminalSessions {
-                        workspace_id,
-                        sessions: vec![],
-                    })
-                    .await;
+                match self.context.persistence.list_terminal_sessions(workspace_id) {
+                    Ok(sessions) => {
+                        let _ = reply_tx
+                            .send(AppEvent::RestorableTerminalSessions {
+                                workspace_id,
+                                sessions,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "RESTORE_LIST_FAILED".into(),
+                                message: format!("Failed to list terminal sessions: {}", e),
+                            })
+                            .await;
+                    }
+                }
             }
 
             // --- Extended git commands (M5-03, M5-04, M5-05) ---
@@ -1869,6 +1888,22 @@ impl Dispatcher {
             .max_by_key(|s| s.started_at)
             .or_else(|| sessions.values().max_by_key(|s| s.started_at))
             .map(|s| s.project_root.clone())
+    }
+
+    /// Like find_active_project_root, but sends an error event if None.
+    async fn active_root_or_err(&self, reply_tx: &mpsc::Sender<AppEvent>) -> Option<PathBuf> {
+        match self.find_active_project_root().await {
+            Some(p) => Some(p),
+            None => {
+                let _ = reply_tx
+                    .send(AppEvent::Error {
+                        code: "NO_ACTIVE_SESSION".into(),
+                        message: "No active session — start a session before calling this command".into(),
+                    })
+                    .await;
+                None
+            }
+        }
     }
 }
 

--- a/crates/terminal-daemon/src/git_engine.rs
+++ b/crates/terminal-daemon/src/git_engine.rs
@@ -195,6 +195,7 @@ pub async fn diff_full(cwd: &Path, base: &str, head: &str) -> Result<String> {
 // ---------------------------------------------------------------------------
 
 pub async fn worktree_add(cwd: &Path, path: &Path, branch: &str) -> Result<()> {
+    validate_git_ref(branch).map_err(GitError::CommandFailed)?;
     let path_str = path.to_string_lossy();
     run_git(cwd, &["worktree", "add", &path_str, "-b", branch]).await?;
     Ok(())
@@ -666,7 +667,7 @@ pub async fn working_dir_file_diff(cwd: &Path, file_path: &Path) -> Result<Strin
 pub async fn push_branch(cwd: &Path, remote: &str, branch: &str) -> Result<String> {
     validate_git_ref(remote).map_err(GitError::CommandFailed)?;
     validate_git_ref(branch).map_err(GitError::CommandFailed)?;
-    let output = run_git(cwd, &["push", remote, branch]).await?;
+    let _ = run_git(cwd, &["push", remote, branch]).await?;
     let actual_branch = current_branch(cwd).await?.unwrap_or_else(|| branch.to_string());
     Ok(actual_branch)
 }
@@ -677,13 +678,13 @@ pub async fn pull_branch(cwd: &Path, remote: &str, branch: Option<&str>) -> Resu
     if let Some(b) = branch {
         validate_git_ref(b).map_err(GitError::CommandFailed)?;
     }
-    let before_head = head_oid(cwd).await.unwrap_or_default();
+    let before_head = head_oid(cwd).await?;
     if let Some(b) = branch {
         run_git(cwd, &["pull", remote, b]).await?;
     } else {
         run_git(cwd, &["pull", remote]).await?;
     }
-    let after_head = head_oid(cwd).await.unwrap_or_default();
+    let after_head = head_oid(cwd).await?;
     if before_head == after_head {
         return Ok(0);
     }
@@ -706,10 +707,19 @@ pub async fn list_merge_conflicts(cwd: &Path) -> Result<Vec<MergeConflictFile>> 
     let mut conflicts = Vec::new();
     for line in output.lines() {
         let path = std::path::PathBuf::from(line.trim());
-        let content = std::fs::read_to_string(cwd.join(&path)).unwrap_or_default();
-        // Parse ours / theirs from conflict markers
-        let (ours, theirs) = parse_conflict_sections(&content);
-        conflicts.push(MergeConflictFile { path, ours, theirs, base: None });
+        match std::fs::read_to_string(cwd.join(&path)) {
+            Ok(content) => {
+                let (ours, theirs) = parse_conflict_sections(&content);
+                conflicts.push(MergeConflictFile { path, ours, theirs, base: None });
+            }
+            Err(e) => {
+                return Err(GitError::CommandFailed(format!(
+                    "Cannot read conflict file {}: {}",
+                    path.display(),
+                    e
+                )));
+            }
+        }
     }
     Ok(conflicts)
 }

--- a/crates/terminal-daemon/src/persistence.rs
+++ b/crates/terminal-daemon/src/persistence.rs
@@ -3,7 +3,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use terminal_core::models::{
-    FailPhase, Run, RunState, Session, TerminalSessionMeta, WorktreeMeta,
+    FailPhase, RestorableTerminalSession, Run, RunState, Session, TerminalSessionMeta, Workspace,
+    WorktreeMeta,
 };
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -38,6 +39,7 @@ impl Persistence {
         fs::create_dir_all(base_dir.join("runs"))?;
         fs::create_dir_all(base_dir.join("worktrees"))?;
         fs::create_dir_all(base_dir.join("terminals"))?;
+        fs::create_dir_all(base_dir.join("workspaces"))?;
         Ok(Self { base_dir })
     }
 
@@ -103,6 +105,65 @@ impl Persistence {
             fs::remove_file(&path)?;
         }
         Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Workspaces
+    // -----------------------------------------------------------------------
+
+    pub fn save_workspace(&self, ws: &Workspace) -> Result<()> {
+        let path = self.base_dir.join("workspaces").join(format!("{}.json", ws.id));
+        let data = serde_json::to_string_pretty(ws)?;
+        Self::atomic_write(&path, data.as_bytes())
+    }
+
+    pub fn load_workspace(&self, id: Uuid) -> Result<Option<Workspace>> {
+        let path = self.base_dir.join("workspaces").join(format!("{}.json", id));
+        match fs::read_to_string(&path) {
+            Ok(data) => {
+                let ws: Workspace = serde_json::from_str(&data)?;
+                Ok(Some(ws))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn list_workspaces(&self) -> Result<Vec<Workspace>> {
+        let dir = self.base_dir.join("workspaces");
+        let mut workspaces = Vec::new();
+
+        if !dir.exists() {
+            return Ok(workspaces);
+        }
+
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            match fs::read_to_string(&path).and_then(|data| {
+                serde_json::from_str::<Workspace>(&data)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            }) {
+                Ok(ws) => workspaces.push(ws),
+                Err(e) => {
+                    warn!("Failed to parse workspace file {:?}: {}", path, e);
+                }
+            }
+        }
+
+        Ok(workspaces)
+    }
+
+    pub fn delete_workspace(&self, id: Uuid) -> Result<()> {
+        let path = self.base_dir.join("workspaces").join(format!("{}.json", id));
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -380,6 +441,21 @@ impl Persistence {
             }
         }
         Ok(metas)
+    }
+
+    pub fn list_terminal_sessions(&self, workspace_id: Uuid) -> Result<Vec<RestorableTerminalSession>> {
+        let metas = self.list_terminal_metas()?;
+        let sessions: Vec<RestorableTerminalSession> = metas
+            .into_iter()
+            .filter(|m| m.workspace_id == workspace_id)
+            .map(|m| RestorableTerminalSession {
+                session_id: m.session_id,
+                pane_id: m.pane_id,
+                cwd: m.cwd,
+                last_active_at: m.last_active_at,
+            })
+            .collect();
+        Ok(sessions)
     }
 
     pub fn delete_terminal_meta(&self, session_id: Uuid) -> Result<()> {

--- a/crates/terminal-daemon/src/pty/manager.rs
+++ b/crates/terminal-daemon/src/pty/manager.rs
@@ -12,7 +12,7 @@ use terminal_core::protocol::v1::AppEvent;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::sync::{broadcast, mpsc, Mutex};
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 use crate::safety::broadcast_event;
 
@@ -276,20 +276,28 @@ impl PtyManager {
     }
 
     /// Resize the PTY window via TIOCSWINSZ ioctl on the master fd.
-    pub async fn resize(&self, session_id: Uuid, cols: u16, rows: u16) {
+    pub async fn resize(&self, session_id: Uuid, cols: u16, rows: u16) -> Result<(), String> {
         let sessions = self.sessions.lock().await;
-        if let Some(session) = sessions.get(&session_id) {
-            let ws = nix::libc::winsize {
-                ws_row: rows,
-                ws_col: cols,
-                ws_xpixel: 0,
-                ws_ypixel: 0,
-            };
-            unsafe {
-                nix::libc::ioctl(session.master_raw_fd, nix::libc::TIOCSWINSZ, &ws);
-            }
-            info!("PTY session {} resized to {}x{}", session_id, cols, rows);
+        let session = sessions
+            .get(&session_id)
+            .ok_or_else(|| format!("session not found: {}", session_id))?;
+
+        let ws = nix::libc::winsize {
+            ws_row: rows,
+            ws_col: cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+
+        let rc = unsafe { nix::libc::ioctl(session.master_raw_fd, nix::libc::TIOCSWINSZ, &ws) };
+        if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            warn!("PTY session {} resize failed: {}", session_id, err);
+            return Err(format!("ioctl TIOCSWINSZ failed: {}", err));
         }
+
+        info!("PTY session {} resized to {}x{}", session_id, cols, rows);
+        Ok(())
     }
 
     /// Close a PTY session.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,29 +1,26 @@
-# O que fazer agora
+# Quick Start
 
-## Resposta curta
+## Short answer
 
-- Sim, já tens **interface gráfica nativa no OS**: `make desktop`.
-- Se quiseres modo terminal: `make run` e `cc ...`.
+- Want a **native desktop app**? Run `make desktop`
+- Want to develop locally? Run `make run` and open your browser
+- Need to run tests? Use `make test`
 
-## Arranque rápido
-
-```bash
-make setup
-make desktop
-```
-
-## Testes
+## Quick start
 
 ```bash
-make test
-make ui-test
+make help       # See all available commands
+make run        # Start daemon + frontend
+make desktop    # Build native Tauri app
+make test       # Run all tests
 ```
 
-## Fluxo recomendado na app desktop
+## Development workflow
 
-1. Clicar `Doctor`
-2. Criar branch em `branch start`
-3. Rever com `Review`
-4. Fazer `Commit`
-5. Sincronizar com `Sync`
-6. Abrir `PR`
+1. Run `make run` to start the dev environment
+2. Open http://localhost:5173 in your browser
+3. Enter a project path and start a session
+4. Type a prompt to run Claude in an isolated git worktree
+5. Review the changes and merge/revert as needed
+
+For more details, see the [main README](../README.md).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { AppProvider, useAppState, useAppDispatch } from './context/AppContext.tsx';
 import { SendProvider } from './context/SendContext.tsx';
 import { useWebSocket } from './hooks/useWebSocket.ts';
+import { debug } from './util/log';
 import { ActivityBar } from './components/ActivityBar.tsx';
 import { SidebarContainer } from './components/sidebar/SidebarContainer.tsx';
 import { DirtyWarningModal } from './components/DirtyWarningModal.tsx';
@@ -316,7 +317,7 @@ function AppContent() {
     const detectAndConnect = async () => {
       // Check for Tauri runtime (injected by the native shell, not present in browsers)
       if (!(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__) {
-        console.log('[Browser] Tauri runtime not detected, using standalone mode');
+        debug('[Browser] Tauri runtime not detected, using standalone mode');
         setDaemonUrl('ws://127.0.0.1:3000/ws');
         setTauriMode(false);
         return;
@@ -324,26 +325,26 @@ function AppContent() {
 
       try {
         const { invoke } = await import('@tauri-apps/api/core');
-        console.log('[Tauri] API module resolved, polling for daemon...');
+        debug('[Tauri] API module resolved, polling for daemon...');
 
         for (let attempt = 0; attempt < 15; attempt++) {
           if (cancelled) return;
           try {
             const info = await invoke<{ port: number; token: string }>('get_daemon_info');
-            console.log('[Tauri] Daemon ready on port', info.port);
+            debug('[Tauri] Daemon ready on port', info.port);
             setDaemonUrl(`ws://127.0.0.1:${info.port}/ws`);
             setAuthToken(info.token);
             setTauriMode(true);
             return;
           } catch (e) {
-            console.log(`[Tauri] Attempt ${attempt + 1} failed:`, e);
+            debug(`[Tauri] Attempt ${attempt + 1} failed:`, e);
             await new Promise(r => setTimeout(r, 300 * (attempt + 1)));
           }
         }
         console.error('[Tauri] Daemon did not become ready after 15 attempts');
         setTauriMode(true);
       } catch {
-        console.log('[Browser] Tauri API import failed, using standalone mode');
+        debug('[Browser] Tauri API import failed, using standalone mode');
         setDaemonUrl('ws://127.0.0.1:3000/ws');
         setTauriMode(false);
       }

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AppCommand, AppEvent } from '../types/protocol';
+import { debug } from '../util/log';
 
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'authenticating' | 'connected';
 
@@ -19,20 +20,20 @@ export function useWebSocket({ url, token, onEvent }: UseWebSocketOptions) {
     if (!url) return;
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
 
-    console.log('[WS] Connecting to', url);
+    debug('[WS] Connecting to', url);
     setStatus('connecting');
     const ws = new WebSocket(url);
     wsRef.current = ws;
 
     ws.onopen = () => {
-      console.log('[WS] Connected, sending auth');
+      debug('[WS] Connected, sending auth');
       setStatus('authenticating');
       ws.send(JSON.stringify({ type: 'Auth', token }));
     };
 
     ws.onmessage = (event) => {
-      if (import.meta.env.DEV && !event.data.includes('TerminalOutput')) {
-        console.log('[WS] Received:', event.data);
+      if (!event.data.includes('TerminalOutput')) {
+        debug('[WS] Received:', event.data);
       }
       try {
         const data: AppEvent = JSON.parse(event.data);
@@ -52,7 +53,7 @@ export function useWebSocket({ url, token, onEvent }: UseWebSocketOptions) {
     };
 
     ws.onclose = (ev) => {
-      console.log('[WS] Closed:', ev.code, ev.reason);
+      debug('[WS] Closed:', ev.code, ev.reason);
       setStatus('disconnected');
       wsRef.current = null;
       // Auto-reconnect after 3s (only if url is valid)

--- a/frontend/src/util/log.ts
+++ b/frontend/src/util/log.ts
@@ -1,0 +1,5 @@
+export function debug(...args: unknown[]) {
+  if (import.meta.env.DEV || localStorage.getItem('terminal:debug')) {
+    console.log(...args);
+  }
+}


### PR DESCRIPTION
## Summary

This PR fixes all 11 issues marked with the 'haiku' label, addressing critical hangs, missing error handling, and documentation gaps.

### Backend Fixes (8 issues)

**Critical:**
- **C1 (#64)**: Git commands silently hang when no active session. Added `active_root_or_err()` helper that emits `NO_ACTIVE_SESSION` error for all affected commands (StageFile, UnstageFile, GetRepoStatus, GetCommitHistory, ListDirectory, GetChangedFiles, CheckoutBranch, CreateBranch, ListBranches, GetFileDiff)
- **C2 (#65)**: StageFile/UnstageFile never acknowledge success. Now emit `RepoStatusResult` on successful operations
- **C4a (#94)**: ListRestoredTerminalSessions returned empty vec. Implemented `persistence.list_terminal_sessions()` filtered by workspace_id
- **C5a (#97)**: Missing workspace persistence API. Implemented save/load/list/delete with atomic writes

**Major:**
- **M1 (#70)**: `unwrap_or_default()` on git OIDs hid real errors. Replaced with proper error propagation in `pull_branch()`
- **M2 (#71)**: Branch names not validated in all entry points. Added validation to `worktree_add()`
- **M3 (#72)**: PTY resize ioctl return value ignored. Now checks return code, emits error on failure, updated CLAUDE.md
- **M15 (#84)**: Unsafe file read in merge conflict handler. Propagated I/O errors instead of silently substituting empty strings

### Frontend Fix (1 issue)

- **Minor1 (#87)**: Debug console.log statements in production. Created `debug()` utility and replaced all console.log calls (kept console.error/warn)

### Documentation (2 issues)

- **M11 (#80)**: Makefile didn't exist. Created with targets: help, run, stop, desktop, test, test-rust, test-frontend, lint. Updated docs/next-steps.md
- **M13 (#82)**: Incomplete env-var documentation. Added comprehensive table to README with TERMINAL_HOST, TERMINAL_PORT, TERMINAL_DATA_DIR, TERMINAL_CLAUDE_BINARY, RUST_LOG

## Test Plan

- [ ] Verify cargo check passes (all warnings resolved)
- [ ] Run `make help` to see all targets
- [ ] Test without active session to see NO_ACTIVE_SESSION error
- [ ] Stage/unstage files and verify RepoStatusResult is received
- [ ] ListRestoredTerminalSessions returns non-empty list
- [ ] Workspace persistence methods work without errors
- [ ] Build succeeds with no warnings