### PR TITLE
Fix M1 regression: allow pull in repos with unborn HEAD

### DIFF
--- a/crates/terminal-daemon/src/git_engine.rs
+++ b/crates/terminal-daemon/src/git_engine.rs
@@ -678,20 +678,30 @@ pub async fn pull_branch(cwd: &Path, remote: &str, branch: Option<&str>) -> Resu
     if let Some(b) = branch {
         validate_git_ref(b).map_err(GitError::CommandFailed)?;
     }
-    let before_head = head_oid(cwd).await?;
+
+    // Try to get HEAD before pull, but don't fail if repo has no commits yet (unborn HEAD)
+    let before_head = head_oid(cwd).await.ok();
+
     if let Some(b) = branch {
         run_git(cwd, &["pull", remote, b]).await?;
     } else {
         run_git(cwd, &["pull", remote]).await?;
     }
-    let after_head = head_oid(cwd).await?;
-    if before_head == after_head {
-        return Ok(0);
+
+    // Only compute diff if we had a valid HEAD before
+    if let Some(before) = before_head {
+        let after_head = head_oid(cwd).await?;
+        if before == after_head {
+            return Ok(0);
+        }
+        let count_str = run_git(cwd, &["rev-list", "--count", &format!("{}..{}", before, after_head)])
+            .await
+            .unwrap_or_else(|_| "0".into());
+        Ok(count_str.trim().parse().unwrap_or(0))
+    } else {
+        // Fresh repo bootstrap: can't compute commit count, return 0
+        Ok(0)
     }
-    let count_str = run_git(cwd, &["rev-list", "--count", &format!("{}..{}", before_head, after_head)])
-        .await
-        .unwrap_or_else(|_| "0".into());
-    Ok(count_str.trim().parse().unwrap_or(0))
 }
 
 /// Fetch a remote.


### PR DESCRIPTION
## Issue

M1 (#70) fix introduced a regression: `pull_branch()` now hard-fails when the repository has an unborn HEAD (no commits yet). This breaks bootstrap workflows where a fresh repository needs to pull from a remote.

The error occurs because `head_oid(cwd).await?` propagates an error immediately when `git rev-parse HEAD` fails in a fresh repo, preventing the pull from even being attempted.

## Solution

Changed `head_oid()` error handling from immediate failure to graceful degradation:
- Use `.ok()` to tolerate missing HEAD before the pull
- Allow the pull to proceed regardless of pre-pull HEAD status
- Skip commit counting for fresh repos (return 0)
- Still propagate real errors from post-pull HEAD queries

This preserves error checking for actual failures while enabling the legitimate use case of pulling to bootstrap a new repository.

## Test Cases

- Fresh repo with no commits: `git pull` should work and return 0
- Normal repo: commit counting should work as before
- Real failures (permissions, network): should still error cleanly