### PR TITLE
Fix all sonnet-labeled issues: backend hardening, frontend polish, CI setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Test
+
+on:
+  push:
+    branches: [main, master, 'claude/**']
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  rust-tests:
+    name: Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.88
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.88
+
+      - name: Cache Rust build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install git (required by tests)
+        run: sudo apt-get install -y git
+
+      - name: Run Rust tests
+        run: cargo test -p terminal-core -p terminal-daemon
+
+  frontend-checks:
+    name: Frontend checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: TypeScript type check
+        working-directory: frontend
+        run: npx tsc --noEmit --skipLibCheck
+
+      - name: Frontend build
+        working-directory: frontend
+        run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,10 @@ Key domain groups:
 
 | Milestone | Issues | Status |
 |-----------|--------|--------|
-| M1 Foundation | #12, #15, #19, #24, #28 | ✅ Implemented |
+| M1 Foundation | #12, #15, #19, #24, #28 | ⚠️ Partial (#24 per-client workspace tracking pending #99) |
 | M2 Panes | #10, #11, #13, #18, #22 | ✅ Implemented |
 | M3 Modes | #14, #16, #17 | ✅ Implemented |
-| M4 Terminal | #20, #21, #23, #26, #27, #38 | ✅ Implemented |
+| M4 Terminal | #20, #21, #23, #26, #27, #38 | ⚠️ Partial (#38 restore affordance pending #96) |
 | M5 Git | #25, #29, #30, #36, #37 | ✅ Implemented |
 | M6 Browser | #31, #32 | ✅ Implemented |
 | M7 Polish | #33, #34, #35 | ✅ Implemented |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: run test desktop lint
+
+run:
+	docker compose up
+
+test:
+	docker compose run --rm test
+
+desktop:
+	cd crates/terminal-app && cargo tauri dev
+
+lint:
+	cd frontend && npx tsc --noEmit --skipLibCheck && npm run build

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ terminal/
 | `RUST_LOG` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 | `TERMINAL_HOST` | `127.0.0.1` | Daemon bind address |
 | `TERMINAL_PORT` | `3000` | Daemon port |
+| `TERMINAL_DATA_DIR` | `~/.terminal-daemon` | Directory for persisted sessions, runs, and auth token |
+| `TERMINAL_AUTH_TOKEN` | _(auto-generated)_ | WebSocket auth token; generated on first start if absent |
+| `TERMINAL_CLAUDE_BINARY` | `claude` | Path or name of the Claude CLI binary |
 
 ## Protocol
 

--- a/crates/terminal-core/src/protocol/v1.rs
+++ b/crates/terminal-core/src/protocol/v1.rs
@@ -77,6 +77,11 @@ pub enum AppCommand {
         stash_message: String,
     },
 
+    // Stash mutations (M4)
+    PopStash { index: usize },
+    ApplyStash { index: usize },
+    DropStash { index: usize },
+
     // Branch operations
     ListBranches,
 
@@ -306,6 +311,8 @@ pub enum AppEvent {
         diff: String,
         stat: Option<DiffStat>,
     },
+    StashApplied { index: usize, had_conflicts: bool },
+    StashDropped { index: usize },
     DirtyState {
         status: DirtyStatus,
     },
@@ -1058,5 +1065,68 @@ mod tests {
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains("\"type\":\"PushBranch\""));
         let _: AppCommand = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn pop_stash_command_roundtrip() {
+        let cmd = AppCommand::PopStash { index: 1 };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"type\":\"PopStash\""));
+        let deserialized: AppCommand = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            AppCommand::PopStash { index } => assert_eq!(index, 1),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn apply_stash_command_roundtrip() {
+        let cmd = AppCommand::ApplyStash { index: 2 };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"type\":\"ApplyStash\""));
+        let deserialized: AppCommand = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            AppCommand::ApplyStash { index } => assert_eq!(index, 2),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn drop_stash_command_roundtrip() {
+        let cmd = AppCommand::DropStash { index: 0 };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"type\":\"DropStash\""));
+        let deserialized: AppCommand = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            AppCommand::DropStash { index } => assert_eq!(index, 0),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn stash_applied_event_roundtrip() {
+        let evt = AppEvent::StashApplied { index: 1, had_conflicts: true };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains("\"type\":\"StashApplied\""));
+        let deserialized: AppEvent = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            AppEvent::StashApplied { index, had_conflicts } => {
+                assert_eq!(index, 1);
+                assert!(had_conflicts);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn stash_dropped_event_roundtrip() {
+        let evt = AppEvent::StashDropped { index: 3 };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains("\"type\":\"StashDropped\""));
+        let deserialized: AppEvent = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            AppEvent::StashDropped { index } => assert_eq!(index, 3),
+            _ => panic!("wrong variant"),
+        }
     }
 }

--- a/crates/terminal-core/src/protocol/v1.rs
+++ b/crates/terminal-core/src/protocol/v1.rs
@@ -1185,6 +1185,9 @@ mod tests {
             },
             AppCommand::GetStatus,
             AppCommand::Ping,
+            AppCommand::PopStash { index: 0 },
+            AppCommand::ApplyStash { index: 0 },
+            AppCommand::DropStash { index: 0 },
         ];
 
         // Exhaustive match — future variants MUST appear here or compilation
@@ -1240,6 +1243,9 @@ mod tests {
                 AppCommand::SearchFiles { .. } => "SearchFiles",
                 AppCommand::GetStatus => "GetStatus",
                 AppCommand::Ping => "Ping",
+                AppCommand::PopStash { .. } => "PopStash",
+                AppCommand::ApplyStash { .. } => "ApplyStash",
+                AppCommand::DropStash { .. } => "DropStash",
             }
         }
 
@@ -1482,6 +1488,8 @@ mod tests {
             AppEvent::StatusUpdate { active_runs: 0, session_count: 0 },
             AppEvent::Pong,
             AppEvent::Error { code: "c".into(), message: "m".into() },
+            AppEvent::StashApplied { index: 0, had_conflicts: false },
+            AppEvent::StashDropped { index: 0 },
         ];
 
         fn ensure_exhaustive(e: &AppEvent) -> &'static str {
@@ -1543,6 +1551,8 @@ mod tests {
                 AppEvent::StatusUpdate { .. } => "StatusUpdate",
                 AppEvent::Pong => "Pong",
                 AppEvent::Error { .. } => "Error",
+                AppEvent::StashApplied { .. } => "StashApplied",
+                AppEvent::StashDropped { .. } => "StashDropped",
             }
         }
 

--- a/crates/terminal-daemon/src/daemon_context.rs
+++ b/crates/terminal-daemon/src/daemon_context.rs
@@ -12,6 +12,17 @@ use terminal_core::protocol::v1::AppEvent;
 use tokio::sync::{broadcast, mpsc, Mutex};
 use uuid::Uuid;
 
+/// Opaque identifier for a connected WebSocket client.
+/// Generated per-connection in server.rs and threaded through the command channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ClientId(pub Uuid);
+
+impl ClientId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
 /// Internal state for tracking active runs.
 pub struct ActiveRun {
     #[allow(dead_code)]
@@ -32,8 +43,8 @@ pub struct DaemonContext {
     pub runner: Arc<ClaudeRunner>,
     /// Workspaces registry (M1-05)
     pub workspaces: Arc<Mutex<HashMap<Uuid, Workspace>>>,
-    /// Active workspace id per client (simplified: global for now)
-    pub active_workspace_id: Arc<Mutex<Option<Uuid>>>,
+    /// Active workspace id per client (keyed by ClientId)
+    pub active_workspace_ids: Arc<Mutex<HashMap<ClientId, Uuid>>>,
     /// Workspace-scoped broadcast channels (M1-05)
     pub workspace_channels: Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>,
 }
@@ -54,7 +65,7 @@ impl DaemonContext {
             concurrency: Arc::new(Mutex::new(HashMap::new())),
             runner,
             workspaces: Arc::new(Mutex::new(HashMap::new())),
-            active_workspace_id: Arc::new(Mutex::new(None)),
+            active_workspace_ids: Arc::new(Mutex::new(HashMap::new())),
             workspace_channels: Arc::new(Mutex::new(HashMap::new())),
         }
     }

--- a/crates/terminal-daemon/src/dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatcher.rs
@@ -2182,6 +2182,7 @@ impl Dispatcher {
             base_head: base_head.clone(),
             merge_base: base_head.clone(),
             last_modified: chrono::Utc::now(),
+            repo_root: Some(project_root.clone()),
         };
         if let Err(e) = self.context.persistence.save_worktree_meta(run_id, &meta) {
             warn!("Failed to persist worktree meta for run {}: {}", run_id, e);

--- a/crates/terminal-daemon/src/dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatcher.rs
@@ -1,5 +1,5 @@
 use crate::claude_runner::{output_file_path, RunnerEvent};
-use crate::daemon_context::{ActiveRun, DaemonContext};
+use crate::daemon_context::{ActiveRun, ClientId, DaemonContext};
 use crate::persistence::Persistence;
 use crate::pty::PtyManager;
 use crate::safety::broadcast_event;
@@ -16,6 +16,13 @@ use uuid::Uuid;
 pub struct Dispatcher {
     context: Arc<DaemonContext>,
     pty_manager: Arc<PtyManager>,
+}
+
+/// Result of a successful worktree preparation.
+struct WorktreeInfo {
+    branch_name: String,
+    worktree_path: PathBuf,
+    base_head: String,
 }
 
 impl Dispatcher {
@@ -35,7 +42,8 @@ impl Dispatcher {
     }
 
     /// Handle a command and send response to the requesting client.
-    pub async fn handle(&self, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
+    pub async fn handle(&self, client_id: ClientId, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
+        let _ = client_id; // forwarded to workspace_dispatcher; suppressed elsewhere
         match cmd {
             AppCommand::Auth { .. } => {
                 // Auth is handled at the server level, not here
@@ -1017,28 +1025,34 @@ impl Dispatcher {
             }
 
             AppCommand::StageFile { path } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    if let Err(e) = crate::git_engine::stage_file(&root, &path).await {
-                        let _ = reply_tx
-                            .send(AppEvent::Error {
-                                code: "STAGE_FAILED".into(),
-                                message: e.to_string(),
-                            })
-                            .await;
-                    }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                if let Err(e) = crate::git_engine::stage_file(&root, &path).await {
+                    let _ = reply_tx
+                        .send(AppEvent::Error {
+                            code: "STAGE_FAILED".into(),
+                            message: e.to_string(),
+                        })
+                        .await;
+                    return;
+                }
+                if let Ok(status) = crate::git_engine::repo_status_snapshot(&root).await {
+                    let _ = reply_tx.send(AppEvent::RepoStatusResult { status }).await;
                 }
             }
 
             AppCommand::UnstageFile { path } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    if let Err(e) = crate::git_engine::unstage_file(&root, &path).await {
-                        let _ = reply_tx
-                            .send(AppEvent::Error {
-                                    code: "UNSTAGE_FAILED".into(),
-                                    message: e.to_string(),
-                            })
-                            .await;
-                    }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                if let Err(e) = crate::git_engine::unstage_file(&root, &path).await {
+                    let _ = reply_tx
+                        .send(AppEvent::Error {
+                            code: "UNSTAGE_FAILED".into(),
+                            message: e.to_string(),
+                        })
+                        .await;
+                    return;
+                }
+                if let Ok(status) = crate::git_engine::repo_status_snapshot(&root).await {
+                    let _ = reply_tx.send(AppEvent::RepoStatusResult { status }).await;
                 }
             }
 
@@ -1130,7 +1144,7 @@ impl Dispatcher {
                 let dispatcher = crate::dispatchers::workspace_dispatcher::WorkspaceDispatcher::new(
                     self.context.clone(),
                 );
-                dispatcher.handle(cmd, reply_tx).await;
+                dispatcher.handle(client_id, cmd, reply_tx).await;
             }
 
             // --- PTY commands (M4-01) ---
@@ -1175,7 +1189,14 @@ impl Dispatcher {
             }
 
             AppCommand::ResizeTerminal { session_id, cols, rows } => {
-                self.pty_manager.resize(session_id, cols, rows).await;
+                if let Err(e) = self.pty_manager.resize(session_id, cols, rows).await {
+                    let _ = reply_tx
+                        .send(AppEvent::Error {
+                            code: "PTY_RESIZE_FAILED".into(),
+                            message: e,
+                        })
+                        .await;
+                }
             }
 
             AppCommand::ListTerminalSessions { workspace_id } => {
@@ -1186,23 +1207,122 @@ impl Dispatcher {
             }
 
             AppCommand::RestoreTerminalSession { previous_session_id, workspace_id } => {
-                // Placeholder: PTY sessions can't persist across daemon restarts in pipe mode.
-                // Full persistence handled in M4-06.
-                let _ = reply_tx
-                    .send(AppEvent::TerminalSessionRestoreFailed {
-                        previous_session_id,
-                        reason: "Session restoration not yet supported in pipe mode".into(),
-                    })
-                    .await;
+                let meta = match self.context.persistence.load_terminal_session(previous_session_id) {
+                    Ok(m) => m,
+                    Err(crate::persistence::PersistenceError::NotFound(_)) => {
+                        let _ = reply_tx
+                            .send(AppEvent::TerminalSessionRestoreFailed {
+                                previous_session_id,
+                                reason: "No saved session with that id".into(),
+                            })
+                            .await;
+                        return;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::TerminalSessionRestoreFailed {
+                                previous_session_id,
+                                reason: format!("Load failed: {}", e),
+                            })
+                            .await;
+                        return;
+                    }
+                };
+                let shell = meta.shell_path.to_string_lossy().to_string();
+                let cwd = meta.cwd.clone();
+                let pane_id = format!("terminal-restored-{}", workspace_id);
+                match self.pty_manager
+                    .create_session(workspace_id, pane_id, Some(shell.clone()), Some(cwd.clone()), None, None)
+                    .await
+                {
+                    Ok(new_session_id) => {
+                        let _ = self.context.persistence.delete_terminal_session(previous_session_id);
+                        let _ = reply_tx
+                            .send(AppEvent::TerminalSessionRestored {
+                                previous_session_id,
+                                new_session_id,
+                                cwd,
+                                workspace_id,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::TerminalSessionRestoreFailed {
+                                previous_session_id,
+                                reason: format!("Failed to spawn PTY: {}", e),
+                            })
+                            .await;
+                    }
+                }
             }
 
             AppCommand::ListRestoredTerminalSessions { workspace_id } => {
+                let sessions = match self.context.persistence.list_terminal_sessions(workspace_id) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "RESTORE_LIST_FAILED".into(),
+                                message: format!("Failed to list terminal sessions: {}", e),
+                            })
+                            .await;
+                        return;
+                    }
+                };
                 let _ = reply_tx
-                    .send(AppEvent::RestorableTerminalSessions {
-                        workspace_id,
-                        sessions: vec![],
-                    })
+                    .send(AppEvent::RestorableTerminalSessions { workspace_id, sessions })
                     .await;
+            }
+
+            // --- Stash mutations (M4) ---
+
+            AppCommand::PopStash { index } => {
+                if let Some(root) = self.find_active_project_root().await {
+                    match crate::git_engine::stash_pop(&root, index).await {
+                        Ok(had_conflicts) => {
+                            let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
+                        }
+                        Err(e) => {
+                            let _ = reply_tx.send(AppEvent::Error {
+                                code: "STASH_FAILED".into(),
+                                message: e.to_string(),
+                            }).await;
+                        }
+                    }
+                }
+            }
+
+            AppCommand::ApplyStash { index } => {
+                if let Some(root) = self.find_active_project_root().await {
+                    match crate::git_engine::stash_apply(&root, index).await {
+                        Ok(had_conflicts) => {
+                            let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
+                        }
+                        Err(e) => {
+                            let _ = reply_tx.send(AppEvent::Error {
+                                code: "STASH_FAILED".into(),
+                                message: e.to_string(),
+                            }).await;
+                        }
+                    }
+                }
+            }
+
+            AppCommand::DropStash { index } => {
+                if let Some(root) = self.find_active_project_root().await {
+                    match crate::git_engine::stash_drop(&root, index).await {
+                        Ok(()) => {
+                            let _ = reply_tx.send(AppEvent::StashDropped { index }).await;
+                        }
+                        Err(e) => {
+                            let _ = reply_tx.send(AppEvent::Error {
+                                code: "STASH_FAILED".into(),
+                                message: e.to_string(),
+                            }).await;
+                        }
+                    }
+                }
             }
 
             // --- Extended git commands (M5-03, M5-04, M5-05) ---
@@ -1273,142 +1393,30 @@ impl Dispatcher {
         let project_root = session.project_root.clone();
         let is_git = crate::git_engine::is_git_repo(&project_root).await;
 
-        // Git worktree setup
+        // Git worktree setup (delegated to helper)
         let mut branch_name = String::new();
         let mut worktree_path: Option<PathBuf> = None;
         let mut base_head = String::new();
         let mut actual_working_dir = project_root.clone();
 
         if is_git {
-            // Check concurrency: lock -> check -> insert -> unlock (no await gap)
-            {
-                let mut conc = self.context.concurrency.lock().await;
-                if let Some(existing_run_id) = conc.get(&project_root) {
-                    let _ = reply_tx
-                        .send(AppEvent::Error {
-                            code: "REPO_BUSY".into(),
-                            message: format!(
-                                "Repository {} already has active run {}",
-                                project_root.display(),
-                                existing_run_id
-                            ),
-                        })
-                        .await;
-                    return;
+            match self.prepare_worktree(
+                &project_root,
+                run_id,
+                session_id,
+                skip_dirty_check,
+                &prompt,
+                &mode,
+                &reply_tx,
+            ).await {
+                Ok(info) => {
+                    actual_working_dir = info.worktree_path.clone();
+                    worktree_path = Some(info.worktree_path);
+                    branch_name = info.branch_name;
+                    base_head = info.base_head;
                 }
-                conc.insert(project_root.clone(), run_id);
+                Err(()) => return, // error already sent to reply_tx
             }
-
-            // Guard repo state
-            if let Err(e) = crate::git_engine::guard_repo_state(&project_root).await {
-                // Cleanup concurrency
-                self.context.concurrency.lock().await.remove(&project_root);
-                let _ = reply_tx
-                    .send(AppEvent::Error {
-                        code: "GIT_STATE_ERROR".into(),
-                        message: format!("Repository not in clean state: {}", e),
-                    })
-                    .await;
-                return;
-            }
-
-            // Dirty working directory check (unless explicitly skipped)
-            if !skip_dirty_check {
-                let dirty = crate::git_engine::working_dir_status(&project_root)
-                    .await
-                    .unwrap_or_else(|_| DirtyStatus {
-                        staged: vec![],
-                        unstaged: vec![],
-                    });
-
-                if !dirty.staged.is_empty() || !dirty.unstaged.is_empty() {
-                    // Release concurrency lock before returning
-                    self.context.concurrency.lock().await.remove(&project_root);
-                    // Send DirtyWarning event -- frontend will show modal
-                    let _ = reply_tx
-                        .send(AppEvent::DirtyWarning {
-                            status: dirty,
-                            session_id,
-                            prompt: prompt.clone(),
-                            mode: mode.clone(),
-                        })
-                        .await;
-                    return;
-                }
-            }
-
-            // Get base HEAD
-            match crate::git_engine::head_oid(&project_root).await {
-                Ok(oid) => base_head = oid,
-                Err(e) => {
-                    self.context.concurrency.lock().await.remove(&project_root);
-                    let _ = reply_tx
-                        .send(AppEvent::Error {
-                            code: "GIT_ERROR".into(),
-                            message: format!("Failed to read HEAD: {}", e),
-                        })
-                        .await;
-                    return;
-                }
-            }
-
-            // Generate branch name and worktree path
-            let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
-            let short_uuid = &run_id.to_string()[..8];
-            branch_name = format!("llm/{}-{}", timestamp, short_uuid);
-            let wt_path = project_root.join(".terminal-worktrees").join(short_uuid);
-
-            // Create .terminal-worktrees/ dir
-            let wt_parent = match wt_path.parent() {
-                Some(p) => p,
-                None => {
-                    self.context.concurrency.lock().await.remove(&project_root);
-                    let _ = reply_tx
-                        .send(AppEvent::Error {
-                            code: "IO_ERROR".into(),
-                            message: "Invalid worktree path: no parent directory".into(),
-                        })
-                        .await;
-                    return;
-                }
-            };
-            if let Err(e) = tokio::fs::create_dir_all(wt_parent).await {
-                self.context.concurrency.lock().await.remove(&project_root);
-                let _ = reply_tx
-                    .send(AppEvent::Error {
-                        code: "IO_ERROR".into(),
-                        message: format!("Failed to create worktrees dir: {}", e),
-                    })
-                    .await;
-                return;
-            }
-
-            // Create worktree
-            if let Err(e) = crate::git_engine::worktree_add(&project_root, &wt_path, &branch_name).await {
-                self.context.concurrency.lock().await.remove(&project_root);
-                let _ = reply_tx
-                    .send(AppEvent::Error {
-                        code: "GIT_ERROR".into(),
-                        message: format!("Failed to create worktree: {}", e),
-                    })
-                    .await;
-                return;
-            }
-
-            // Save worktree metadata
-            let meta = WorktreeMeta {
-                worktree_path: wt_path.clone(),
-                branch_name: branch_name.clone(),
-                base_head: base_head.clone(),
-                merge_base: base_head.clone(),
-                last_modified: chrono::Utc::now(),
-            };
-            if let Err(e) = self.context.persistence.save_worktree_meta(run_id, &meta) {
-                warn!("Failed to persist worktree meta for run {}: {}", run_id, e);
-            }
-
-            actual_working_dir = wt_path.clone();
-            worktree_path = Some(wt_path);
         }
 
         let run = Run {
@@ -1446,33 +1454,8 @@ impl Dispatcher {
 
         drop(sessions); // Release lock before spawning
 
-        // Pre-flight: verify the Claude binary works before spawning a run.
-        // Surfaces "not installed / not authenticated" as a structured event
-        // instead of a cryptic spawn error that appears for ~1s and stops.
-        if let Err(pf) = self.context.runner.preflight().await {
-            self.broadcast(&AppEvent::RunPreflightFailed {
-                run_id,
-                reason: pf.reason.clone(),
-                suggestion: pf.suggestion.clone(),
-            });
-            self.broadcast(&AppEvent::RunFailed {
-                run_id,
-                error: pf.reason,
-                phase: FailPhase::Preflight,
-            });
-            // Persist the failure so it appears in run history.
-            let failed_run = Run {
-                state: RunState::Failed {
-                    error: pf.suggestion,
-                    phase: FailPhase::Preflight,
-                },
-                ended_at: Some(chrono::Utc::now()),
-                last_modified: chrono::Utc::now(),
-                ..run.clone()
-            };
-            if let Err(e) = self.context.persistence.save_run(&failed_run) {
-                warn!("failed to persist preflight-failed run {}: {}", run_id, e);
-            }
+        // Pre-flight check (delegated to helper)
+        if self.run_preflight(run_id, &run).await.is_err() {
             return;
         }
 
@@ -1869,6 +1852,192 @@ impl Dispatcher {
             .max_by_key(|s| s.started_at)
             .or_else(|| sessions.values().max_by_key(|s| s.started_at))
             .map(|s| s.project_root.clone())
+    }
+
+    /// Like `find_active_project_root`, but emits an Error event and returns None if no session found.
+    async fn active_root_or_err(&self, reply_tx: &mpsc::Sender<AppEvent>) -> Option<PathBuf> {
+        match self.find_active_project_root().await {
+            Some(p) => Some(p),
+            None => {
+                let _ = reply_tx
+                    .send(AppEvent::Error {
+                        code: "NO_ACTIVE_SESSION".into(),
+                        message: "No active session — start a session before calling this command".into(),
+                    })
+                    .await;
+                None
+            }
+        }
+    }
+
+    /// Run the Claude binary preflight check and emit structured events on failure.
+    ///
+    /// Returns `Ok(())` when preflight passes, `Err(())` when it fails (events already broadcast).
+    async fn run_preflight(&self, run_id: Uuid, run: &Run) -> Result<(), ()> {
+        if let Err(pf) = self.context.runner.preflight().await {
+            self.broadcast(&AppEvent::RunPreflightFailed {
+                run_id,
+                reason: pf.reason.clone(),
+                suggestion: pf.suggestion.clone(),
+            });
+            self.broadcast(&AppEvent::RunFailed {
+                run_id,
+                error: pf.reason,
+                phase: FailPhase::Preflight,
+            });
+            let failed_run = Run {
+                state: RunState::Failed {
+                    error: pf.suggestion,
+                    phase: FailPhase::Preflight,
+                },
+                ended_at: Some(chrono::Utc::now()),
+                last_modified: chrono::Utc::now(),
+                ..run.clone()
+            };
+            if let Err(e) = self.context.persistence.save_run(&failed_run) {
+                warn!("failed to persist preflight-failed run {}: {}", run_id, e);
+            }
+            return Err(());
+        }
+        Ok(())
+    }
+
+    /// Prepare a git worktree for the run, returning [`WorktreeInfo`] with paths and metadata.
+    ///
+    /// Handles concurrency checks, dirty-state detection, HEAD read, and `git worktree add`.
+    /// Emits reply_tx errors and cleans up the concurrency guard on failure.
+    /// Returns `Err(())` when an error was sent (caller should return early).
+    async fn prepare_worktree(
+        &self,
+        project_root: &PathBuf,
+        run_id: Uuid,
+        session_id: Uuid,
+        skip_dirty_check: bool,
+        prompt: &str,
+        mode: &RunMode,
+        reply_tx: &mpsc::Sender<AppEvent>,
+    ) -> Result<WorktreeInfo, ()> {
+        // Concurrency guard: one run per repo at a time
+        {
+            let mut conc = self.context.concurrency.lock().await;
+            if let Some(existing_run_id) = conc.get(project_root) {
+                let _ = reply_tx
+                    .send(AppEvent::Error {
+                        code: "REPO_BUSY".into(),
+                        message: format!(
+                            "Repository {} already has active run {}",
+                            project_root.display(),
+                            existing_run_id
+                        ),
+                    })
+                    .await;
+                return Err(());
+            }
+            conc.insert(project_root.clone(), run_id);
+        }
+
+        // Guard repo state
+        if let Err(e) = crate::git_engine::guard_repo_state(project_root).await {
+            self.context.concurrency.lock().await.remove(project_root);
+            let _ = reply_tx
+                .send(AppEvent::Error {
+                    code: "GIT_STATE_ERROR".into(),
+                    message: format!("Repository not in clean state: {}", e),
+                })
+                .await;
+            return Err(());
+        }
+
+        // Dirty working directory check (unless explicitly skipped)
+        if !skip_dirty_check {
+            let dirty = crate::git_engine::working_dir_status(project_root)
+                .await
+                .unwrap_or_else(|_| DirtyStatus { staged: vec![], unstaged: vec![] });
+            if !dirty.staged.is_empty() || !dirty.unstaged.is_empty() {
+                self.context.concurrency.lock().await.remove(project_root);
+                let _ = reply_tx
+                    .send(AppEvent::DirtyWarning {
+                        status: dirty,
+                        session_id,
+                        prompt: prompt.to_string(),
+                        mode: mode.clone(),
+                    })
+                    .await;
+                return Err(());
+            }
+        }
+
+        // Read base HEAD
+        let base_head = match crate::git_engine::head_oid(project_root).await {
+            Ok(oid) => oid,
+            Err(e) => {
+                self.context.concurrency.lock().await.remove(project_root);
+                let _ = reply_tx
+                    .send(AppEvent::Error {
+                        code: "GIT_ERROR".into(),
+                        message: format!("Failed to read HEAD: {}", e),
+                    })
+                    .await;
+                return Err(());
+            }
+        };
+
+        // Generate branch name and worktree path
+        let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+        let short_uuid = &run_id.to_string()[..8];
+        let branch_name = format!("llm/{}-{}", timestamp, short_uuid);
+        let wt_path = project_root.join(".terminal-worktrees").join(short_uuid);
+
+        // Create .terminal-worktrees/ dir
+        let wt_parent = match wt_path.parent() {
+            Some(p) => p.to_path_buf(),
+            None => {
+                self.context.concurrency.lock().await.remove(project_root);
+                let _ = reply_tx
+                    .send(AppEvent::Error {
+                        code: "IO_ERROR".into(),
+                        message: "Invalid worktree path: no parent directory".into(),
+                    })
+                    .await;
+                return Err(());
+            }
+        };
+        if let Err(e) = tokio::fs::create_dir_all(&wt_parent).await {
+            self.context.concurrency.lock().await.remove(project_root);
+            let _ = reply_tx
+                .send(AppEvent::Error {
+                    code: "IO_ERROR".into(),
+                    message: format!("Failed to create worktrees dir: {}", e),
+                })
+                .await;
+            return Err(());
+        }
+
+        // Create the worktree
+        if let Err(e) = crate::git_engine::worktree_add(project_root, &wt_path, &branch_name).await {
+            self.context.concurrency.lock().await.remove(project_root);
+            let _ = reply_tx
+                .send(AppEvent::Error {
+                    code: "GIT_ERROR".into(),
+                    message: format!("Failed to create worktree: {}", e),
+                })
+                .await;
+            return Err(());
+        }
+
+        // Persist worktree metadata
+        let meta = WorktreeMeta {
+            worktree_path: wt_path.clone(),
+            branch_name: branch_name.clone(),
+            base_head: base_head.clone(),
+            merge_base: base_head.clone(),
+            last_modified: chrono::Utc::now(),
+        };
+        if let Err(e) = self.context.persistence.save_worktree_meta(run_id, &meta) {
+            warn!("Failed to persist worktree meta for run {}: {}", run_id, e);
+        }
+
+        Ok(WorktreeInfo { branch_name, worktree_path: wt_path, base_head })
     }
 }
 

--- a/crates/terminal-daemon/src/dispatchers/workspace_dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatchers/workspace_dispatcher.rs
@@ -1,6 +1,6 @@
 // Workspace domain dispatcher (M1-04, M1-05)
 
-use crate::daemon_context::DaemonContext;
+use crate::daemon_context::{ClientId, DaemonContext};
 use std::sync::Arc;
 use terminal_core::models::{PaneLayout, Workspace, WorkspaceSummary};
 use terminal_core::protocol::v1::{AppCommand, AppEvent};
@@ -17,7 +17,8 @@ impl WorkspaceDispatcher {
         Self { ctx }
     }
 
-    pub async fn handle(&self, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
+    pub async fn handle(&self, client_id: ClientId, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
+        let _ = client_id; // used in ActivateWorkspace; suppressed for others
         match cmd {
             AppCommand::ListWorkspaces => {
                 let workspaces = self.ctx.workspaces.lock().await;
@@ -87,7 +88,7 @@ impl WorkspaceDispatcher {
             AppCommand::ActivateWorkspace { workspace_id } => {
                 let exists = self.ctx.workspaces.lock().await.contains_key(&workspace_id);
                 if exists {
-                    *self.ctx.active_workspace_id.lock().await = Some(workspace_id);
+                    self.ctx.active_workspace_ids.lock().await.insert(client_id, workspace_id);
                     self.ctx.broadcast(&AppEvent::WorkspaceActivated { workspace_id });
                     let _ = reply_tx
                         .send(AppEvent::WorkspaceActivated { workspace_id })

--- a/crates/terminal-daemon/src/git_engine.rs
+++ b/crates/terminal-daemon/src/git_engine.rs
@@ -508,6 +508,35 @@ pub async fn stash_push(cwd: &Path, message: &str) -> Result<()> {
     Ok(())
 }
 
+/// Apply a stash by index (git stash apply stash@{N}).
+pub async fn stash_apply(cwd: &Path, index: usize) -> Result<bool> {
+    let stash_ref = format!("stash@{{{}}}", index);
+    let output = run_git(cwd, &["stash", "apply", &stash_ref]).await;
+    match output {
+        Ok(_) => Ok(false), // no conflicts
+        Err(GitError::CommandFailed(msg)) if msg.contains("CONFLICT") => Ok(true),
+        Err(e) => Err(e),
+    }
+}
+
+/// Pop a stash by index (git stash pop stash@{N}).
+pub async fn stash_pop(cwd: &Path, index: usize) -> Result<bool> {
+    let stash_ref = format!("stash@{{{}}}", index);
+    let output = run_git(cwd, &["stash", "pop", &stash_ref]).await;
+    match output {
+        Ok(_) => Ok(false), // no conflicts
+        Err(GitError::CommandFailed(msg)) if msg.contains("CONFLICT") => Ok(true),
+        Err(e) => Err(e),
+    }
+}
+
+/// Drop a stash by index (git stash drop stash@{N}).
+pub async fn stash_drop(cwd: &Path, index: usize) -> Result<()> {
+    let stash_ref = format!("stash@{{{}}}", index);
+    run_git(cwd, &["stash", "drop", &stash_ref]).await?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Sidebar operations (Phase 3)
 // ---------------------------------------------------------------------------
@@ -666,7 +695,7 @@ pub async fn working_dir_file_diff(cwd: &Path, file_path: &Path) -> Result<Strin
 pub async fn push_branch(cwd: &Path, remote: &str, branch: &str) -> Result<String> {
     validate_git_ref(remote).map_err(GitError::CommandFailed)?;
     validate_git_ref(branch).map_err(GitError::CommandFailed)?;
-    let output = run_git(cwd, &["push", remote, branch]).await?;
+    let _output = run_git(cwd, &["push", remote, branch]).await?;
     let actual_branch = current_branch(cwd).await?.unwrap_or_else(|| branch.to_string());
     Ok(actual_branch)
 }
@@ -677,13 +706,13 @@ pub async fn pull_branch(cwd: &Path, remote: &str, branch: Option<&str>) -> Resu
     if let Some(b) = branch {
         validate_git_ref(b).map_err(GitError::CommandFailed)?;
     }
-    let before_head = head_oid(cwd).await.unwrap_or_default();
+    let before_head = head_oid(cwd).await?;
     if let Some(b) = branch {
         run_git(cwd, &["pull", remote, b]).await?;
     } else {
         run_git(cwd, &["pull", remote]).await?;
     }
-    let after_head = head_oid(cwd).await.unwrap_or_default();
+    let after_head = head_oid(cwd).await?;
     if before_head == after_head {
         return Ok(0);
     }
@@ -706,7 +735,8 @@ pub async fn list_merge_conflicts(cwd: &Path) -> Result<Vec<MergeConflictFile>> 
     let mut conflicts = Vec::new();
     for line in output.lines() {
         let path = std::path::PathBuf::from(line.trim());
-        let content = std::fs::read_to_string(cwd.join(&path)).unwrap_or_default();
+        let content = std::fs::read_to_string(cwd.join(&path))
+            .map_err(|e| GitError::CommandFailed(format!("Cannot read conflict file {:?}: {}", path, e)))?;
         // Parse ours / theirs from conflict markers
         let (ours, theirs) = parse_conflict_sections(&content);
         conflicts.push(MergeConflictFile { path, ours, theirs, base: None });

--- a/crates/terminal-daemon/src/lib.rs
+++ b/crates/terminal-daemon/src/lib.rs
@@ -10,6 +10,7 @@ pub mod safety;
 pub mod search_engine;
 pub mod server;
 
+use crate::daemon_context::ClientId;
 use crate::persistence::Persistence;
 use dispatcher::Dispatcher;
 use rand::Rng;
@@ -66,8 +67,9 @@ pub async fn start_server(
     // Event broadcast channel
     let (event_tx, _) = broadcast::channel::<String>(256);
 
-    // Command channel (from WS clients to dispatcher)
-    let (command_tx, mut command_rx) = mpsc::channel(64);
+    // Command channel (from WS clients to dispatcher) — (ClientId, command, reply)
+    let (command_tx, mut command_rx) =
+        mpsc::channel::<(ClientId, terminal_core::protocol::v1::AppCommand, mpsc::Sender<terminal_core::protocol::v1::AppEvent>)>(64);
 
     let state = Arc::new(DaemonState {
         auth_token: token.clone(),
@@ -114,8 +116,8 @@ pub async fn start_server(
         persistence.clone(),
     ));
     tokio::spawn(async move {
-        while let Some((cmd, reply_tx)) = command_rx.recv().await {
-            dispatcher.handle(cmd, reply_tx).await;
+        while let Some((client_id, cmd, reply_tx)) = command_rx.recv().await {
+            dispatcher.handle(client_id, cmd, reply_tx).await;
         }
     });
 

--- a/crates/terminal-daemon/src/persistence.rs
+++ b/crates/terminal-daemon/src/persistence.rs
@@ -38,6 +38,7 @@ impl Persistence {
         fs::create_dir_all(base_dir.join("runs"))?;
         fs::create_dir_all(base_dir.join("worktrees"))?;
         fs::create_dir_all(base_dir.join("terminals"))?;
+        fs::create_dir_all(base_dir.join("workspaces"))?;
         Ok(Self { base_dir })
     }
 
@@ -393,6 +394,45 @@ impl Persistence {
         Ok(())
     }
 
+    pub fn list_terminal_sessions(&self, workspace_id: uuid::Uuid) -> Result<Vec<terminal_core::models::RestorableTerminalSession>> {
+        let dir = self.base_dir.join("terminals");
+        if !dir.exists() {
+            return Ok(vec![]);
+        }
+        let mut sessions = Vec::new();
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            match fs::read_to_string(&path).and_then(|data| {
+                serde_json::from_str::<terminal_core::models::TerminalSessionMeta>(&data)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            }) {
+                Ok(meta) if meta.workspace_id == workspace_id => {
+                    sessions.push(terminal_core::models::RestorableTerminalSession {
+                        session_id: meta.session_id,
+                        pane_id: meta.pane_id,
+                        cwd: meta.cwd,
+                        last_active_at: meta.last_active_at,
+                    });
+                }
+                Ok(_) => {}
+                Err(e) => warn!("Failed to parse terminal meta {:?}: {}", path, e),
+            }
+        }
+        Ok(sessions)
+    }
+
+    pub fn delete_terminal_session(&self, session_id: uuid::Uuid) -> Result<()> {
+        self.delete_terminal_meta(session_id)
+    }
+
+    pub fn load_terminal_session(&self, session_id: uuid::Uuid) -> Result<terminal_core::models::TerminalSessionMeta> {
+        self.load_terminal_meta(session_id)
+    }
+
     /// Remove terminal metas older than `max_age_hours` hours.
     pub fn cleanup_stale_terminal_metas(&self, max_age_hours: i64) -> Result<usize> {
         let dir = self.base_dir.join("terminals");
@@ -418,6 +458,59 @@ impl Persistence {
             }
         }
         Ok(cleaned)
+    }
+
+    // -----------------------------------------------------------------------
+    // Workspace persistence (C5a)
+    // -----------------------------------------------------------------------
+
+    pub async fn save_workspace(&self, ws: &terminal_core::models::Workspace) -> std::result::Result<(), PersistenceError> {
+        let path = self.base_dir.join("workspaces").join(format!("{}.json", ws.id));
+        let tmp = self.base_dir.join("workspaces").join(format!("{}.json.tmp", ws.id));
+        let json = serde_json::to_vec_pretty(ws)?;
+        tokio::fs::write(&tmp, &json).await?;
+        tokio::fs::rename(&tmp, &path).await?;
+        Ok(())
+    }
+
+    pub async fn load_workspace(&self, id: uuid::Uuid) -> std::result::Result<Option<terminal_core::models::Workspace>, PersistenceError> {
+        let path = self.base_dir.join("workspaces").join(format!("{}.json", id));
+        match tokio::fs::read_to_string(&path).await {
+            Ok(s) => Ok(Some(serde_json::from_str(&s)?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub async fn list_workspaces(&self) -> std::result::Result<Vec<terminal_core::models::Workspace>, PersistenceError> {
+        let dir = self.base_dir.join("workspaces");
+        let mut out = Vec::new();
+        let mut entries = match tokio::fs::read_dir(&dir).await {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e.into()),
+        };
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") { continue; }
+            match tokio::fs::read_to_string(&path).await {
+                Ok(s) => match serde_json::from_str::<terminal_core::models::Workspace>(&s) {
+                    Ok(w) => out.push(w),
+                    Err(e) => tracing::warn!("skip corrupt workspace {:?}: {}", path, e),
+                },
+                Err(e) => tracing::warn!("skip unreadable workspace {:?}: {}", path, e),
+            }
+        }
+        Ok(out)
+    }
+
+    pub async fn delete_workspace(&self, id: uuid::Uuid) -> std::result::Result<(), PersistenceError> {
+        let path = self.base_dir.join("workspaces").join(format!("{}.json", id));
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
     }
 }
 

--- a/crates/terminal-daemon/src/pty/manager.rs
+++ b/crates/terminal-daemon/src/pty/manager.rs
@@ -276,7 +276,7 @@ impl PtyManager {
     }
 
     /// Resize the PTY window via TIOCSWINSZ ioctl on the master fd.
-    pub async fn resize(&self, session_id: Uuid, cols: u16, rows: u16) {
+    pub async fn resize(&self, session_id: Uuid, cols: u16, rows: u16) -> Result<(), String> {
         let sessions = self.sessions.lock().await;
         if let Some(session) = sessions.get(&session_id) {
             let ws = nix::libc::winsize {
@@ -285,10 +285,16 @@ impl PtyManager {
                 ws_xpixel: 0,
                 ws_ypixel: 0,
             };
-            unsafe {
-                nix::libc::ioctl(session.master_raw_fd, nix::libc::TIOCSWINSZ, &ws);
+            let rc = unsafe { nix::libc::ioctl(session.master_raw_fd, nix::libc::TIOCSWINSZ, &ws) };
+            if rc != 0 {
+                let err = std::io::Error::last_os_error();
+                tracing::warn!("PTY resize ioctl failed for session {}: {}", session_id, err);
+                return Err(format!("ioctl TIOCSWINSZ failed: {}", err));
             }
             info!("PTY session {} resized to {}x{}", session_id, cols, rows);
+            Ok(())
+        } else {
+            Err(format!("Session {} not found", session_id))
         }
     }
 

--- a/crates/terminal-daemon/src/server.rs
+++ b/crates/terminal-daemon/src/server.rs
@@ -1,3 +1,4 @@
+use crate::daemon_context::ClientId;
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
@@ -16,7 +17,7 @@ use tracing::{error, info, warn};
 pub struct DaemonState {
     pub auth_token: String,
     pub event_tx: broadcast::Sender<String>,
-    pub command_tx: mpsc::Sender<(AppCommand, mpsc::Sender<AppEvent>)>,
+    pub command_tx: mpsc::Sender<(ClientId, AppCommand, mpsc::Sender<AppEvent>)>,
 }
 
 pub fn build_router(state: Arc<DaemonState>) -> Router {
@@ -40,8 +41,9 @@ fn event_json(event: &AppEvent) -> String {
 }
 
 async fn handle_socket(socket: WebSocket, state: Arc<DaemonState>) {
+    let client_id = ClientId::new();
     let (mut sender, mut receiver) = socket.split();
-    info!("New WebSocket connection, awaiting auth...");
+    info!("New WebSocket connection ({:?}), awaiting auth...", client_id);
 
     // Step 1: Auth handshake — first message must be Auth command
     let authed = match tokio::time::timeout(
@@ -168,7 +170,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<DaemonState>) {
                     }
                     Ok(cmd) => {
                         let cmd = cmd.sanitize();
-                        if let Err(e) = state.command_tx.send((cmd, response_tx.clone())).await {
+                        if let Err(e) = state.command_tx.send((client_id, cmd, response_tx.clone())).await {
                             error!("Failed to forward command: {}", e);
                         }
                     }
@@ -216,7 +218,7 @@ mod tests {
         let (event_tx, _) = broadcast::channel::<String>(16);
         // command_tx that simply drops all messages
         let (command_tx, _command_rx) =
-            mpsc::channel::<(AppCommand, mpsc::Sender<AppEvent>)>(16);
+            mpsc::channel::<(ClientId, AppCommand, mpsc::Sender<AppEvent>)>(16);
 
         let state = Arc::new(DaemonState {
             auth_token: token.clone(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { AppProvider, useAppState, useAppDispatch } from './context/AppContext.tsx';
 import { SendProvider } from './context/SendContext.tsx';
 import { useWebSocket } from './hooks/useWebSocket.ts';
-import { debug } from './util/log';
 import { ActivityBar } from './components/ActivityBar.tsx';
 import { SidebarContainer } from './components/sidebar/SidebarContainer.tsx';
 import { DirtyWarningModal } from './components/DirtyWarningModal.tsx';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { debug } from './util/log';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AppProvider, useAppState, useAppDispatch } from './context/AppContext.tsx';
 import { SendProvider } from './context/SendContext.tsx';
@@ -316,7 +317,7 @@ function AppContent() {
     const detectAndConnect = async () => {
       // Check for Tauri runtime (injected by the native shell, not present in browsers)
       if (!(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__) {
-        console.log('[Browser] Tauri runtime not detected, using standalone mode');
+        debug('[Browser] Tauri runtime not detected, using standalone mode');
         setDaemonUrl('ws://127.0.0.1:3000/ws');
         setTauriMode(false);
         return;
@@ -324,26 +325,26 @@ function AppContent() {
 
       try {
         const { invoke } = await import('@tauri-apps/api/core');
-        console.log('[Tauri] API module resolved, polling for daemon...');
+        debug('[Tauri] API module resolved, polling for daemon...');
 
         for (let attempt = 0; attempt < 15; attempt++) {
           if (cancelled) return;
           try {
             const info = await invoke<{ port: number; token: string }>('get_daemon_info');
-            console.log('[Tauri] Daemon ready on port', info.port);
+            debug('[Tauri] Daemon ready on port', info.port);
             setDaemonUrl(`ws://127.0.0.1:${info.port}/ws`);
             setAuthToken(info.token);
             setTauriMode(true);
             return;
           } catch (e) {
-            console.log(`[Tauri] Attempt ${attempt + 1} failed:`, e);
+            debug(`[Tauri] Attempt ${attempt + 1} failed:`, e);
             await new Promise(r => setTimeout(r, 300 * (attempt + 1)));
           }
         }
         console.error('[Tauri] Daemon did not become ready after 15 attempts');
         setTauriMode(true);
       } catch {
-        console.log('[Browser] Tauri API import failed, using standalone mode');
+        debug('[Browser] Tauri API import failed, using standalone mode');
         setDaemonUrl('ws://127.0.0.1:3000/ws');
         setTauriMode(false);
       }
@@ -360,7 +361,10 @@ function AppContent() {
       // Route terminal events via CustomEvent (high-frequency, shouldn't go through React state)
       if (event.type === 'TerminalSessionCreated' ||
           event.type === 'TerminalOutput' ||
-          event.type === 'TerminalSessionClosed') {
+          event.type === 'TerminalSessionClosed' ||
+          event.type === 'RestorableTerminalSessions' ||
+          event.type === 'TerminalSessionRestored' ||
+          event.type === 'TerminalSessionRestoreFailed') {
         window.dispatchEvent(new CustomEvent('terminal-event', { detail: event }));
       }
 

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -579,6 +579,14 @@ function reducer(state: AppState, action: Action): AppState {
           // intentionally ignored: only surfaced on demand via a pane query
           return state;
 
+        case 'StashApplied':
+          // intentionally ignored: UI refreshes via follow-up ListStashes/GetRepoStatus
+          return state;
+
+        case 'StashDropped':
+          // intentionally ignored: UI refreshes via follow-up ListStashes
+          return state;
+
         // --- Workspace lifecycle (routed by App.tsx to workspace state store;
         //     the legacy reducer doesn't mirror workspace state — it only
         //     knows about the AI session workspace. Intentionally ignored

--- a/frontend/src/core/events/eventRouter.test.ts
+++ b/frontend/src/core/events/eventRouter.test.ts
@@ -98,6 +98,8 @@ const SAMPLES: Record<AppEvent['type'], AppEvent> = {
   StashList: { type: 'StashList', stashes: [] },
   StashFiles: { type: 'StashFiles', stash_index: 0, files: [] },
   StashDiff: { type: 'StashDiff', stash_index: 0, diff: '', stat: null },
+  StashApplied: { type: 'StashApplied', index: 0, had_conflicts: false },
+  StashDropped: { type: 'StashDropped', index: 0 },
   DirtyState: { type: 'DirtyState', status: { staged: [], unstaged: [] } },
   DirtyWarning: {
     type: 'DirtyWarning',
@@ -196,6 +198,8 @@ describe('EventRouter — C3 completeness', () => {
         'RunReverted',
         'CommitCreated',
         'TerminalOutput',
+        'StashApplied',
+        'StashDropped',
       ]);
       if (!deliberatelyIgnored.has(tag)) {
         expect(

--- a/frontend/src/core/events/eventRouter.ts
+++ b/frontend/src/core/events/eventRouter.ts
@@ -229,6 +229,12 @@ export class EventRouter {
           stat: event.stat,
         });
         break;
+      case 'StashApplied':
+        // intentionally ignored: UI refreshes via follow-up ListStashes/GetRepoStatus
+        break;
+      case 'StashDropped':
+        // intentionally ignored: UI refreshes via follow-up ListStashes
+        break;
       case 'DirtyState':
         dispatch({ type: 'SET_DIRTY_STATE', status: event.status });
         break;

--- a/frontend/src/core/events/eventRouter.ts
+++ b/frontend/src/core/events/eventRouter.ts
@@ -106,14 +106,32 @@ export class EventRouter {
         dispatch({ type: 'SET_ACTIVE_RUN', runId: null });
         dispatch({ type: 'UPSERT_RUN', run: event.summary });
         dispatch({ type: 'CLEAR_BLOCKING' });
+        dispatch({ type: 'CLEAR_RUN_METRICS' });
         break;
       case 'RunFailed':
         dispatch({ type: 'SET_ACTIVE_RUN', runId: null });
         dispatch({ type: 'CLEAR_BLOCKING' });
+        dispatch({ type: 'CLEAR_RUN_METRICS' });
+        break;
+      case 'RunToolUse':
+        dispatch({
+          type: 'APPEND_TOOL_CALL',
+          call: { tool_id: event.tool_id, tool_name: event.tool_name, input_preview: event.tool_input_preview, status: 'pending' },
+        });
+        break;
+      case 'RunToolResult':
+        dispatch({ type: 'UPDATE_TOOL_RESULT', toolId: event.tool_id, isError: event.is_error, preview: event.preview });
+        break;
+      case 'RunMetrics':
+        dispatch({
+          type: 'SET_RUN_METRICS',
+          metrics: { num_turns: event.num_turns, cost_usd: event.cost_usd, input_tokens: event.input_tokens, output_tokens: event.output_tokens },
+        });
         break;
       case 'RunCancelled':
         dispatch({ type: 'SET_ACTIVE_RUN', runId: null });
         dispatch({ type: 'CLEAR_BLOCKING' });
+        dispatch({ type: 'CLEAR_RUN_METRICS' });
         break;
       case 'RunList':
         dispatch({ type: 'SET_RUNS', runs: event.runs });
@@ -150,9 +168,6 @@ export class EventRouter {
       case 'FileDiffResult':
         dispatch({ type: 'SET_DIFF_CONTENT', file: event.file_path, diff: event.diff, stat: event.stat });
         break;
-      case 'RepoStatusResult':
-        dispatch({ type: 'SET_REPO_STATUS', status: event.status });
-        break;
       case 'CommitHistoryResult':
         dispatch({ type: 'SET_COMMIT_HISTORY', commits: event.commits });
         break;
@@ -182,6 +197,44 @@ export class EventRouter {
         break;
       case 'ConflictResolved':
         dispatch({ type: 'REMOVE_CONFLICT', filePath: event.file_path });
+        break;
+      case 'RestorableTerminalSessions':
+        dispatch({ type: 'SET_RESTORABLE_SESSIONS', sessions: event.sessions });
+        break;
+      case 'TerminalSessionRestored':
+        dispatch({ type: 'REMOVE_RESTORABLE_SESSION', sessionId: event.previous_session_id });
+        dispatch({
+          type: 'ADD_TERMINAL_SESSION',
+          session: {
+            session_id: event.new_session_id,
+            workspace_id: event.workspace_id,
+            shell: '',
+            cwd: event.cwd,
+            created_at: new Date().toISOString(),
+            last_active_at: new Date().toISOString(),
+          },
+        });
+        break;
+      case 'TerminalSessionRestoreFailed':
+        dispatch({ type: 'SET_GIT_ERROR', error: `Restore failed: ${event.reason}` });
+        break;
+      case 'RepoStatusResult':
+        dispatch({ type: 'SET_REPO_STATUS', status: event.status });
+        dispatch({ type: 'GIT_IN_FLIGHT_REMOVE', key: 'refresh' });
+        dispatch({ type: 'GIT_IN_FLIGHT_REMOVE', key: 'commit' });
+        break;
+      case 'CommitCreated':
+        dispatch({ type: 'GIT_IN_FLIGHT_REMOVE', key: 'commit' });
+        break;
+      case 'PushCompleted':
+        dispatch({ type: 'GIT_IN_FLIGHT_REMOVE', key: 'push' });
+        break;
+      case 'PullCompleted':
+        dispatch({ type: 'GIT_IN_FLIGHT_REMOVE', key: 'pull' });
+        break;
+      case 'GitOperationFailed':
+        dispatch({ type: 'SET_GIT_ERROR', error: `${event.operation} failed: ${event.reason}` });
+        dispatch({ type: 'GIT_IN_FLIGHT_REMOVE', key: event.operation });
         break;
     }
   }

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AppCommand, AppEvent } from '../types/protocol';
+import { debug } from '../util/log';
 
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'authenticating' | 'connected';
 
@@ -9,36 +10,64 @@ interface UseWebSocketOptions {
   onEvent: (event: AppEvent) => void;
 }
 
+const MAX_RETRY_COUNT = 20;
+const MAX_QUEUE_SIZE = 256;
+
+// Compute exponential backoff with jitter: starts at 1s, doubles to 30s max.
+function backoffMs(retryCount: number): number {
+  const base = Math.min(30_000, 1_000 * 2 ** retryCount);
+  const jitter = Math.random() * 0.25 * base;
+  return base + jitter;
+}
+
 export function useWebSocket({ url, token, onEvent }: UseWebSocketOptions) {
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
   const wsRef = useRef<WebSocket | null>(null);
   const onEventRef = useRef(onEvent);
   onEventRef.current = onEvent;
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Pending command queue for buffering while disconnected.
+  const queueRef = useRef<AppCommand[]>([]);
+
+  const drainQueue = useCallback((ws: WebSocket) => {
+    while (queueRef.current.length > 0 && ws.readyState === WebSocket.OPEN) {
+      const cmd = queueRef.current.shift()!;
+      ws.send(JSON.stringify(cmd));
+    }
+  }, []);
 
   const connect = useCallback(() => {
     if (!url) return;
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
 
-    console.log('[WS] Connecting to', url);
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+
+    debug('[WS] Connecting to', url);
     setStatus('connecting');
     const ws = new WebSocket(url);
     wsRef.current = ws;
 
     ws.onopen = () => {
-      console.log('[WS] Connected, sending auth');
+      debug('[WS] Connected, sending auth');
       setStatus('authenticating');
       ws.send(JSON.stringify({ type: 'Auth', token }));
     };
 
     ws.onmessage = (event) => {
       if (import.meta.env.DEV && !event.data.includes('TerminalOutput')) {
-        console.log('[WS] Received:', event.data);
+        debug('[WS] Received:', event.data);
       }
       try {
         const data: AppEvent = JSON.parse(event.data);
 
         if (data.type === 'AuthSuccess') {
           setStatus('connected');
+          retryCountRef.current = 0;
+          drainQueue(ws);
         } else if (data.type === 'AuthFailed') {
           setStatus('disconnected');
           ws.close();
@@ -52,34 +81,65 @@ export function useWebSocket({ url, token, onEvent }: UseWebSocketOptions) {
     };
 
     ws.onclose = (ev) => {
-      console.log('[WS] Closed:', ev.code, ev.reason);
+      debug('[WS] Closed:', ev.code, ev.reason);
       setStatus('disconnected');
       wsRef.current = null;
-      // Auto-reconnect after 3s (only if url is valid)
-      if (url) setTimeout(connect, 3000);
+
+      if (!url) return;
+      if (retryCountRef.current >= MAX_RETRY_COUNT) {
+        debug('[WS] Max retries reached, stopping auto-reconnect');
+        return;
+      }
+
+      const delay = backoffMs(retryCountRef.current);
+      retryCountRef.current += 1;
+      debug(`[WS] Reconnecting in ${Math.round(delay)}ms (attempt ${retryCountRef.current})`);
+      retryTimerRef.current = setTimeout(connect, delay);
     };
 
     ws.onerror = (err) => {
       console.error('[WS] Error:', err);
       ws.close();
     };
-  }, [url, token]);
+  }, [url, token, drainQueue]);
 
-  const send = useCallback((command: AppCommand) => {
+  const send = useCallback((command: AppCommand, opts: { queueable?: boolean } = {}) => {
+    const { queueable = true } = opts;
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify(command));
+      return;
+    }
+    if (queueable) {
+      if (queueRef.current.length >= MAX_QUEUE_SIZE) {
+        queueRef.current.shift(); // drop oldest
+        debug('[WS] Queue overflow, dropped oldest command');
+      }
+      queueRef.current.push(command);
+    } else {
+      console.error('[WS] Command dropped (socket not open):', command.type);
     }
   }, []);
 
   const disconnect = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+    retryCountRef.current = MAX_RETRY_COUNT; // prevent auto-reconnect
     wsRef.current?.close();
     wsRef.current = null;
   }, []);
+
+  // Manual reconnect: reset retry counter and try immediately.
+  const reconnect = useCallback(() => {
+    retryCountRef.current = 0;
+    connect();
+  }, [connect]);
 
   useEffect(() => {
     connect();
     return disconnect;
   }, [connect, disconnect]);
 
-  return { status, send, connect, disconnect };
+  return { status, send, connect, disconnect, reconnect };
 }

--- a/frontend/src/panes/browser/BrowserPane.tsx
+++ b/frontend/src/panes/browser/BrowserPane.tsx
@@ -13,6 +13,7 @@ function NavButton({ onClick, title, children }: { onClick: () => void; title: s
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       title={title}
+      aria-label={title}
       style={{
         width: 28,
         height: 28,

--- a/frontend/src/panes/git/GitStatusPane.tsx
+++ b/frontend/src/panes/git/GitStatusPane.tsx
@@ -61,18 +61,44 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
   const send = useSend();
   const state = useAppState();
   const [hoverPath, setHoverPath] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [stagingPath, setStagingPath] = useState<string | null>(null);
+  const [gitError, setGitError] = useState<string | null>(null);
 
   useEffect(() => {
     send({ type: 'GetRepoStatus' });
     send({ type: 'GetChangedFiles', mode: 'working' });
   }, [send]);
 
+  // Clear error when new status arrives and pick up git errors from global state
+  useEffect(() => {
+    if (state.repoStatus) setRefreshing(false);
+  }, [state.repoStatus]);
+
+  // Surface GitOperationFailed from global error state
+  useEffect(() => {
+    if (state.error?.includes('failed:')) {
+      setGitError(state.error);
+      setStagingPath(null);
+    }
+  }, [state.error]);
+
   const files = state.changedFiles?.files ?? [];
   const repoStatus = state.repoStatus;
 
   const refresh = () => {
+    setRefreshing(true);
+    setGitError(null);
     send({ type: 'GetRepoStatus' });
     send({ type: 'GetChangedFiles', mode: 'working' });
+  };
+
+  const handleStage = (path: string) => {
+    setStagingPath(path);
+    setGitError(null);
+    send({ type: 'StageFile', path });
+    // Clear staging indicator when status refreshes
+    setTimeout(() => setStagingPath(null), 3000);
   };
 
   return (
@@ -86,6 +112,32 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
         color: 'var(--text-primary)',
       }}
     >
+      {/* Error banner */}
+      {gitError && (
+        <div
+          role="alert"
+          style={{
+            padding: '6px 12px',
+            backgroundColor: 'rgba(var(--accent-error-rgb), 0.12)',
+            borderBottom: '1px solid rgba(var(--accent-error-rgb), 0.3)',
+            color: 'var(--accent-error)',
+            fontSize: 11,
+            fontFamily: 'var(--font-mono)',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <span>{gitError}</span>
+          <button
+            onClick={() => setGitError(null)}
+            aria-label="Dismiss error"
+            style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: '0 4px', fontSize: 14, lineHeight: 1 }}
+          >
+            ×
+          </button>
+        </div>
+      )}
       {/* Header */}
       <div
         style={{
@@ -119,6 +171,8 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
         <button
           onClick={refresh}
           title="Refresh"
+          aria-label="Refresh repository status"
+          disabled={refreshing}
           style={{
             marginLeft: 'auto',
             display: 'inline-flex',
@@ -126,28 +180,31 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
             gap: 4,
             background: 'transparent',
             border: '1px solid var(--border-default)',
-            color: 'var(--text-muted)',
+            color: refreshing ? 'var(--accent-primary)' : 'var(--text-muted)',
             borderRadius: 5,
             padding: '3px 9px',
-            cursor: 'pointer',
+            cursor: refreshing ? 'wait' : 'pointer',
             fontFamily: 'var(--font-display)',
             fontSize: 11,
             fontWeight: 500,
             transition: 'color 140ms, border-color 140ms, background 140ms',
+            opacity: refreshing ? 0.7 : 1,
           }}
           onMouseEnter={(e) => {
+            if (refreshing) return;
             e.currentTarget.style.color = 'var(--accent-primary)';
             e.currentTarget.style.borderColor = 'var(--accent-primary)';
             e.currentTarget.style.background = 'var(--accent-primary-08)';
           }}
           onMouseLeave={(e) => {
+            if (refreshing) return;
             e.currentTarget.style.color = 'var(--text-muted)';
             e.currentTarget.style.borderColor = 'var(--border-default)';
             e.currentTarget.style.background = 'transparent';
           }}
         >
-          <RotateCw size={11} strokeWidth={1.75} />
-          Refresh
+          <RotateCw size={11} strokeWidth={1.75} style={{ animation: refreshing ? 'spin 1s linear infinite' : 'none' }} />
+          {refreshing ? 'Refreshing...' : 'Refresh'}
         </button>
       </div>
 
@@ -192,29 +249,32 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
                   {pathStr}
                 </span>
                 <button
-                  onClick={() => send({ type: 'StageFile', path: pathStr })}
+                  onClick={() => handleStage(pathStr)}
+                  aria-label={`Stage ${pathStr}`}
+                  disabled={stagingPath === pathStr}
                   style={{
                     background: 'transparent',
                     border: '1px solid var(--accent-primary)',
                     color: 'var(--accent-primary)',
                     borderRadius: 4,
                     padding: '2px 10px',
-                    cursor: 'pointer',
+                    cursor: stagingPath === pathStr ? 'wait' : 'pointer',
                     fontFamily: 'var(--font-display)',
                     fontSize: 10,
                     fontWeight: 600,
                     letterSpacing: '0.02em',
-                    opacity: isHover ? 1 : 0.7,
+                    opacity: stagingPath === pathStr ? 0.5 : (isHover ? 1 : 0.7),
                     transition: 'opacity 120ms, background 120ms',
                   }}
                   onMouseEnter={(e) => {
+                    if (stagingPath === pathStr) return;
                     e.currentTarget.style.background = 'var(--accent-primary-08)';
                   }}
                   onMouseLeave={(e) => {
                     e.currentTarget.style.background = 'transparent';
                   }}
                 >
-                  Stage
+                  {stagingPath === pathStr ? '...' : 'Stage'}
                 </button>
               </div>
             );
@@ -223,7 +283,7 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
       </div>
 
       {/* Commit bar */}
-      <CommitBar onCommit={(msg) => send({ type: 'CreateCommit', message: msg })} />
+      <CommitBar onCommit={(msg) => { setGitError(null); send({ type: 'CreateCommit', message: msg }); }} />
     </div>
   );
 }
@@ -231,6 +291,7 @@ export function GitStatusPane({ pane: _pane }: PaneProps) {
 function CommitBar({ onCommit }: { onCommit: (msg: string) => void }) {
   const [msg, setMsg] = React.useState('');
   const [focused, setFocused] = React.useState(false);
+  const [committing, setCommitting] = React.useState(false);
 
   return (
     <div
@@ -247,8 +308,10 @@ function CommitBar({ onCommit }: { onCommit: (msg: string) => void }) {
         onChange={(e) => setMsg(e.target.value)}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
-        onKeyDown={(e) => { if (e.key === 'Enter' && msg.trim()) { onCommit(msg.trim()); setMsg(''); } }}
+        onKeyDown={(e) => { if (e.key === 'Enter' && msg.trim() && !committing) { setCommitting(true); onCommit(msg.trim()); setMsg(''); setTimeout(() => setCommitting(false), 3000); } }}
         placeholder="commit message..."
+        aria-label="Commit message"
+        disabled={committing}
         style={{
           flex: 1,
           backgroundColor: 'var(--bg-raised)',
@@ -264,8 +327,9 @@ function CommitBar({ onCommit }: { onCommit: (msg: string) => void }) {
         }}
       />
       <button
-        onClick={() => { if (msg.trim()) { onCommit(msg.trim()); setMsg(''); } }}
-        disabled={!msg.trim()}
+        onClick={() => { if (msg.trim() && !committing) { setCommitting(true); onCommit(msg.trim()); setMsg(''); setTimeout(() => setCommitting(false), 3000); } }}
+        disabled={!msg.trim() || committing}
+        aria-label="Create commit"
         style={{
           backgroundColor: msg.trim() ? 'var(--accent-primary)' : 'var(--bg-overlay)',
           color: msg.trim() ? 'var(--bg-base)' : 'var(--text-muted)',

--- a/frontend/src/panes/terminal/TerminalPane.tsx
+++ b/frontend/src/panes/terminal/TerminalPane.tsx
@@ -7,8 +7,17 @@ import { useSend } from '../../context/SendContext';
 import { useAppState } from '../../context/AppContext';
 import { registerPane } from '../registry';
 import type { PaneProps } from '../registry';
+import type { RestorableTerminalSession, SshConfig } from '../../types/protocol';
 
-type SessionState = 'idle' | 'creating' | 'active' | 'lost' | 'restoring';
+type SessionState =
+  | { tag: 'idle' }
+  | { tag: 'checking-restorable' }
+  | { tag: 'restore-prompt'; sessions: RestorableTerminalSession[] }
+  | { tag: 'creating' }
+  | { tag: 'restoring' }
+  | { tag: 'active'; sessionId: string }
+  | { tag: 'lost' }
+  | { tag: 'error'; message: string };
 
 // FIFO queue: panes register when they send CreateTerminalSession,
 // and TerminalSessionCreated events are matched in order.
@@ -78,7 +87,9 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
   // Check if this pane already has a session from a previous mount (e.g., after split)
   const existingSessionId = paneSessionMap.get(pane.id) ?? null;
   const [sessionId, setSessionId] = useState<string | null>(existingSessionId);
-  const [sessionState, setSessionState] = useState<SessionState>(existingSessionId ? 'active' : 'idle');
+  const [sessionState, setSessionState] = useState<SessionState>(
+    existingSessionId ? { tag: 'active', sessionId: existingSessionId } : { tag: 'idle' }
+  );
   const [xtermLoaded, setXtermLoaded] = useState(false);
   const termRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTermHandle | null>(null);
@@ -198,41 +209,110 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
     const rid = pane.resource_id;
     if (typeof rid !== 'string' || !rid.startsWith('ssh://')) return undefined;
     try {
-      // ssh://username@host:port or ssh://username@host:port?identity=/path/to/key
       const url = new URL(rid);
-      return {
+      const config: SshConfig = {
         host: url.hostname,
         port: url.port ? parseInt(url.port, 10) : 22,
         username: url.username || 'root',
-        identity_file: url.searchParams.get('identity') || undefined,
+        identity_file: url.searchParams.get('identity') ?? undefined,
       };
+      return config;
     } catch {
       return undefined;
     }
   })();
 
-  // Create a PTY session when component mounts — uses FIFO queue for reliable matching
+  // Step 1: On mount, check for restorable sessions before creating a new one
   useEffect(() => {
-    if (sessionState !== 'idle') return;
+    if (sessionState.tag !== 'idle' || sshConfig) return; // SSH sessions have no restore
     installGlobalListener();
-    setSessionState('creating');
-    const cmd: Record<string, unknown> = {
-      type: 'CreateTerminalSession',
-      workspace_id: workspaceId,
-      cwd,
+    setSessionState({ tag: 'checking-restorable' });
+    send({ type: 'ListRestoredTerminalSessions', workspace_id: workspaceId });
+  }, [workspaceId, sessionState.tag, send]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Step 2: Listen for restorable sessions response
+  useEffect(() => {
+    if (sessionState.tag !== 'checking-restorable') return;
+    let cancelled = false;
+    const handler = (e: Event) => {
+      const event = (e as CustomEvent).detail;
+      if (event.type === 'RestorableTerminalSessions' && event.workspace_id === workspaceId) {
+        if (cancelled) return;
+        const sessions: RestorableTerminalSession[] = event.sessions ?? [];
+        if (sessions.length > 0) {
+          setSessionState({ tag: 'restore-prompt', sessions });
+        } else {
+          setSessionState({ tag: 'idle' });
+        }
+      }
     };
-    if (sshConfig) {
-      cmd.ssh = sshConfig;
-    }
-    // cmd is structurally an AppCommand for CreateTerminalSession — the
-    // optional `ssh` field isn't on every variant, hence the unknown cast.
-    send(cmd as unknown as Parameters<typeof send>[0]);
-    waitForSession(workspaceId).then((sid) => {
-      paneSessionMap.set(pane.id, sid);
-      setSessionId(sid);
-      setSessionState('active');
-    });
-  }, [workspaceId, sessionState, send]); // eslint-disable-line react-hooks/exhaustive-deps
+    // Timeout: if no response in 3s, just proceed to creating
+    const timer = setTimeout(() => {
+      if (!cancelled) setSessionState({ tag: 'idle' });
+    }, 3_000);
+    window.addEventListener('terminal-event', handler);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      window.removeEventListener('terminal-event', handler);
+    };
+  }, [workspaceId, sessionState.tag]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Step 3: Create a PTY session when component mounts — uses FIFO queue for reliable matching
+  useEffect(() => {
+    if (sessionState.tag !== 'creating') return;
+    let cancelled = false;
+    installGlobalListener();
+
+    send({ type: 'CreateTerminalSession', workspace_id: workspaceId, cwd, ssh: sshConfig });
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Timed out after 10s waiting for terminal session')), 10_000),
+    );
+
+    Promise.race([waitForSession(workspaceId), timeout])
+      .then((sid) => {
+        if (cancelled) return;
+        paneSessionMap.set(pane.id, sid);
+        setSessionId(sid);
+        setSessionState({ tag: 'active', sessionId: sid });
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setSessionState({ tag: 'error', message: err.message });
+      });
+
+    return () => { cancelled = true; };
+  }, [workspaceId, sessionState.tag, send]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Step 4: Handle session restore flow
+  useEffect(() => {
+    if (sessionState.tag !== 'restoring') return;
+    let cancelled = false;
+    const handler = (e: Event) => {
+      const event = (e as CustomEvent).detail;
+      if (event.type === 'TerminalSessionRestored' && event.workspace_id === workspaceId) {
+        if (cancelled) return;
+        const newSid: string = event.new_session_id;
+        paneSessionMap.set(pane.id, newSid);
+        setSessionId(newSid);
+        setSessionState({ tag: 'active', sessionId: newSid });
+      }
+      if (event.type === 'TerminalSessionRestoreFailed') {
+        if (cancelled) return;
+        setSessionState({ tag: 'error', message: event.reason ?? 'Restore failed' });
+      }
+    };
+    const timer = setTimeout(() => {
+      if (!cancelled) setSessionState({ tag: 'error', message: 'Timed out waiting for session restore' });
+    }, 10_000);
+    window.addEventListener('terminal-event', handler);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      window.removeEventListener('terminal-event', handler);
+    };
+  }, [workspaceId, sessionState.tag]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Listen for terminal output and close events (session-specific, not creation)
   useEffect(() => {
@@ -284,7 +364,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
       }
       if (event.type === 'TerminalSessionClosed' && event.session_id === sessionId) {
         paneSessionMap.delete(pane.id);
-        setSessionState('lost');
+        setSessionState({ tag: 'lost' });
       }
     };
     window.addEventListener('terminal-event', handler);
@@ -339,13 +419,114 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
 
   const handleReconnect = () => {
     paneSessionMap.delete(pane.id);
-    setSessionState('idle');
+    setSessionState({ tag: 'idle' });
     setSessionId(null);
+  };
+
+  const handleRestore = (previousSessionId: string) => {
+    setSessionState({ tag: 'restoring' });
+    send({ type: 'RestoreTerminalSession', previous_session_id: previousSessionId, workspace_id: workspaceId });
   };
 
   return (
     <div data-pane-kind="terminal" style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', backgroundColor: 'var(--bg-base)' }}>
-      {sessionState === 'lost' && (
+      {sessionState.tag === 'restore-prompt' && (
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 16,
+            backgroundColor: 'var(--bg-surface)',
+            padding: 24,
+          }}
+          role="region"
+          aria-label="Restore terminal session"
+        >
+          <span style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: 13 }}>
+            Restore a previous session?
+          </span>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, width: '100%', maxWidth: 340 }}>
+            {sessionState.sessions.map((s) => (
+              <button
+                key={s.session_id}
+                onClick={() => handleRestore(s.session_id)}
+                aria-label={`Restore session from ${s.cwd}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '8px 12px',
+                  backgroundColor: 'var(--bg-raised)',
+                  border: '1px solid var(--border-default)',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 11,
+                  color: 'var(--text-primary)',
+                  textAlign: 'left',
+                }}
+              >
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                  {s.cwd}
+                </span>
+                <span style={{ color: 'var(--accent-primary)', marginLeft: 8, flexShrink: 0, fontWeight: 600, fontSize: 10 }}>
+                  Restore
+                </span>
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={() => setSessionState({ tag: 'creating' })}
+            aria-label="Start a new terminal session"
+            style={{
+              padding: '6px 16px',
+              backgroundColor: 'transparent',
+              border: '1px solid var(--border-default)',
+              borderRadius: 5,
+              cursor: 'pointer',
+              fontFamily: 'var(--font-display)',
+              fontSize: 11,
+              color: 'var(--text-muted)',
+            }}
+          >
+            New Terminal
+          </button>
+        </div>
+      )}
+      {sessionState.tag === 'error' && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundColor: 'rgba(0,0,0,0.7)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 12,
+            zIndex: 10,
+          }}
+          role="alert"
+        >
+          <span style={{ color: 'var(--accent-error)', fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: 14 }}>
+            Failed to start terminal
+          </span>
+          <span style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+            {sessionState.message}
+          </span>
+          <button
+            onClick={handleReconnect}
+            aria-label="Retry terminal connection"
+            style={{ padding: '8px 18px', backgroundColor: 'var(--accent-primary)', color: 'var(--bg-base)', border: 'none', borderRadius: 5, cursor: 'pointer', fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 12 }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      {sessionState.tag === 'lost' && (
         <div
           style={{
             position: 'absolute',
@@ -392,7 +573,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
       )}
       {/* xterm.js mount point */}
       <div ref={termRef} style={{ flex: 1, overflow: 'hidden' }} />
-      {!xtermLoaded && sessionState !== 'lost' && (
+      {!xtermLoaded && sessionState.tag !== 'lost' && sessionState.tag !== 'error' && sessionState.tag !== 'restore-prompt' && (
         <div
           style={{
             flex: 1,
@@ -419,9 +600,13 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
             }}
           />
           <span>
-            {sessionState === 'creating'
+            {sessionState.tag === 'creating'
               ? (sshConfig ? `connecting to ${sshConfig.username}@${sshConfig.host}...` : 'starting terminal...')
-              : 'terminal'}
+              : sessionState.tag === 'restoring'
+                ? 'restoring session...'
+                : sessionState.tag === 'checking-restorable'
+                  ? 'checking for previous sessions...'
+                  : 'terminal'}
           </span>
         </div>
       )}

--- a/frontend/src/state/workspace-store.ts
+++ b/frontend/src/state/workspace-store.ts
@@ -7,12 +7,15 @@ import type {
   FileChange,
   FileTreeEntry,
   MergeConflictFile,
+  RunMetrics,
   RunMode,
   RunState,
   RunSummary,
   StashEntry,
+  TerminalSessionSummary,
+  ToolCall,
+  RestorableTerminalSession,
 } from '../types/protocol';
-import type { TerminalSessionSummary } from '../types/protocol';
 
 export interface WorkspaceStore {
   workspaceId: string;
@@ -52,6 +55,17 @@ export interface WorkspaceStore {
 
   // Merge conflicts (M5-05)
   mergeConflicts: MergeConflictFile[];
+
+  // Run metrics and tool calls (M10)
+  runMetrics: RunMetrics | null;
+  runToolCalls: ToolCall[];
+
+  // Restorable terminal sessions (C4c)
+  restorableSessions: RestorableTerminalSession[];
+
+  // In-flight git operations (M9) — key: 'stage:<path>' | 'commit' | 'push' | 'pull' | 'refresh'
+  gitInFlight: Set<string>;
+  gitError: string | null;
 }
 
 export interface RepoStatus {
@@ -97,6 +111,11 @@ export function createWorkspaceStore(workspaceId: string): WorkspaceStore {
     },
     terminalSessions: new Map(),
     mergeConflicts: [],
+    runMetrics: null,
+    runToolCalls: [],
+    restorableSessions: [],
+    gitInFlight: new Set(),
+    gitError: null,
   };
 }
 
@@ -135,7 +154,16 @@ export type WorkspaceAction =
   | { type: 'REMOVE_TERMINAL_SESSION'; sessionId: string }
   | { type: 'SET_TERMINAL_SESSIONS'; sessions: TerminalSessionSummary[] }
   | { type: 'SET_MERGE_CONFLICTS'; files: MergeConflictFile[] }
-  | { type: 'REMOVE_CONFLICT'; filePath: string };
+  | { type: 'REMOVE_CONFLICT'; filePath: string }
+  | { type: 'SET_RUN_METRICS'; metrics: RunMetrics }
+  | { type: 'APPEND_TOOL_CALL'; call: ToolCall }
+  | { type: 'UPDATE_TOOL_RESULT'; toolId: string; isError: boolean; preview: string }
+  | { type: 'CLEAR_RUN_METRICS' }
+  | { type: 'SET_RESTORABLE_SESSIONS'; sessions: RestorableTerminalSession[] }
+  | { type: 'REMOVE_RESTORABLE_SESSION'; sessionId: string }
+  | { type: 'GIT_IN_FLIGHT_ADD'; key: string }
+  | { type: 'GIT_IN_FLIGHT_REMOVE'; key: string }
+  | { type: 'SET_GIT_ERROR'; error: string | null };
 
 export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction): WorkspaceStore {
   switch (action.type) {
@@ -291,6 +319,48 @@ export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction)
         ...state,
         mergeConflicts: state.mergeConflicts.filter((f) => f.path !== action.filePath),
       };
+
+    case 'SET_RUN_METRICS':
+      return { ...state, runMetrics: action.metrics };
+
+    case 'APPEND_TOOL_CALL':
+      return { ...state, runToolCalls: [...state.runToolCalls, action.call] };
+
+    case 'UPDATE_TOOL_RESULT': {
+      const runToolCalls = state.runToolCalls.map((tc) =>
+        tc.tool_id === action.toolId
+          ? { ...tc, status: action.isError ? 'error' as const : 'ok' as const, result_preview: action.preview }
+          : tc,
+      );
+      return { ...state, runToolCalls };
+    }
+
+    case 'CLEAR_RUN_METRICS':
+      return { ...state, runMetrics: null, runToolCalls: [] };
+
+    case 'SET_RESTORABLE_SESSIONS':
+      return { ...state, restorableSessions: action.sessions };
+
+    case 'REMOVE_RESTORABLE_SESSION':
+      return {
+        ...state,
+        restorableSessions: state.restorableSessions.filter((s) => s.session_id !== action.sessionId),
+      };
+
+    case 'GIT_IN_FLIGHT_ADD': {
+      const gitInFlight = new Set(state.gitInFlight);
+      gitInFlight.add(action.key);
+      return { ...state, gitInFlight };
+    }
+
+    case 'GIT_IN_FLIGHT_REMOVE': {
+      const gitInFlight = new Set(state.gitInFlight);
+      gitInFlight.delete(action.key);
+      return { ...state, gitInFlight };
+    }
+
+    case 'SET_GIT_ERROR':
+      return { ...state, gitError: action.error };
 
     default:
       return state;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -97,3 +97,10 @@ body {
   font-family: var(--font-display);
   letter-spacing: 0.01em;
 }
+
+/* Global keyboard focus ring — visible only for keyboard navigation */
+:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+  border-radius: 3px;
+}

--- a/frontend/src/types/protocol.ts
+++ b/frontend/src/types/protocol.ts
@@ -185,6 +185,15 @@ export interface SessionSummary {
   started_at: string;
 }
 
+// --- SSH Config ---
+
+export interface SshConfig {
+  host: string;
+  port: number;
+  username: string;
+  identity_file?: string;
+}
+
 // --- Commands (Client -> Daemon) ---
 
 export type AppCommand =
@@ -207,6 +216,9 @@ export type AppCommand =
   | { type: 'GetStashFiles'; stash_index: number }
   | { type: 'GetStashDiff'; stash_index: number; file_path: string | null }
   | { type: 'CheckDirtyState' }
+  | { type: 'PopStash'; index: number }
+  | { type: 'ApplyStash'; index: number }
+  | { type: 'DropStash'; index: number }
   | { type: 'StashAndRun'; session_id: string; prompt: string; mode: RunMode; stash_message: string }
   // Phase 3: Sidebar commands
   | { type: 'ListDirectory'; path: string }
@@ -226,7 +238,7 @@ export type AppCommand =
   | { type: 'CloseWorkspace'; workspace_id: string }
   | { type: 'ActivateWorkspace'; workspace_id: string }
   // PTY commands (M4-01)
-  | { type: 'CreateTerminalSession'; workspace_id: string; shell?: string; cwd?: string; env?: [string, string][] }
+  | { type: 'CreateTerminalSession'; workspace_id: string; shell?: string; cwd?: string; env?: [string, string][]; ssh?: SshConfig }
   | { type: 'CloseTerminalSession'; session_id: string }
   | { type: 'WriteTerminalInput'; session_id: string; data: string }
   | { type: 'ResizeTerminal'; session_id: string; cols: number; rows: number }
@@ -283,6 +295,8 @@ export type AppEvent =
   | { type: 'StashList'; stashes: StashEntry[] }
   | { type: 'StashFiles'; stash_index: number; files: FileChange[] }
   | { type: 'StashDiff'; stash_index: number; diff: string; stat: DiffStat | null }
+  | { type: 'StashApplied'; index: number; had_conflicts: boolean }
+  | { type: 'StashDropped'; index: number }
   | { type: 'DirtyState'; status: DirtyStatus }
   | { type: 'DirtyWarning'; status: DirtyStatus; session_id: string; prompt: string; mode: RunMode }
   // Phase 3: Sidebar events

--- a/frontend/src/util/log.ts
+++ b/frontend/src/util/log.ts
@@ -1,0 +1,9 @@
+// Debug logger — no-ops in production unless terminal:debug flag is set.
+const isDebug = () =>
+  import.meta.env.DEV || localStorage.getItem('terminal:debug') === 'true';
+
+export function debug(...args: unknown[]): void {
+  if (isDebug()) {
+    console.log(...args);
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Resolves all 25 open issues labeled **sonnet** across backend (Rust), frontend (TypeScript), and docs/CI.

### Backend (Rust)

- **C1 (#64)**: Replace `find_active_project_root()` calls with `active_root_or_err()` helper that emits a structured `Error` event
- **C2 (#65)**: Fix `pull_branch` in `git_engine.rs` to propagate errors with `?` instead of silent `unwrap_or_default`
- **C5 (#70)**: Add `PopStash`, `ApplyStash`, `DropStash` command handlers in dispatcher; emit `StashApplied`/`StashDropped` events
- **M9a (#72)**: Fix `StageFile`/`UnstageFile` to re-emit `RepoStatusResult` after success so the sidebar refreshes
- **C4a (#73)**: Fix `ListRestoredTerminalSessions` to call real persistence instead of returning empty list
- **C4b (#84)**: Implement `RestoreTerminalSession` — creates new PTY session, restores cwd, emits `TerminalSessionRestored`
- **M8a (#94)**: Fix `pty/manager.rs` `resize()` to return `Result<(), String>` and check ioctl return code
- **M8b (#95)**: Add `save_workspace`, `load_workspace`, `list_workspaces`, `delete_workspace` to `persistence.rs`
- **C3 (#97)**: Fix merge conflict error handling in `git_engine.rs` to propagate errors correctly
- **M5a (#99)**: Introduce `ClientId` newtype in `daemon_context.rs`; thread through `server.rs` command channel; `active_workspace_id` is now per-client (`HashMap<ClientId, Uuid>`)
- **Minor3a (#102)**: Extract `run_preflight()` and `prepare_worktree()` helpers from the 200-line `do_start_run()`, each returning `Result<_, ()>` with errors already emitted

### Frontend (TypeScript)

- **M1b (#75)**: Exponential backoff with jitter (`min(30s, 1s * 2^n) + rand(0..1s)`) in `useWebSocket.ts`; max 20 retries
- **M7a (#76)**: Command buffering/queuing when disconnected (max 256); queue drains on `AuthSuccess`
- **M7b (#77)**: `SessionState` refactored from string union to tagged discriminated union in `TerminalPane.tsx`; 10s timeout on session creation; `{ tag: 'error', message }` state with Retry button
- **M10 (#78, #79)**: Wire `RunToolUse`, `RunToolResult`, `RunMetrics`, `CommitCreated`, `PushCompleted`, `PullCompleted`, `GitOperationFailed` to workspace store reducer
- **Minor5 (#87, #91)**: Add `SshConfig` interface to `protocol.ts`; add `ssh?: SshConfig` to `CreateTerminalSession`; eliminates unsafe `as unknown as` cast in TerminalPane
- **Minor4 (#90)**: Global `:focus-visible` CSS ring on all interactive elements; `aria-label` on nav buttons, refresh button, stage button, commit button, commit input
- **C4c (#96)**: Restore affordance in TerminalPane — on mount, queries `ListRestoredTerminalSessions`; shows restore prompt with per-session Restore/New Terminal buttons; `{ tag: 'restoring' }` state with 10s timeout

### Docs & CI

- **C6 (#69)**: Create `.github/workflows/test.yml` — Rust tests (1.88) + frontend TypeScript check + build, triggered on push/PR to main
- **M11 (#80)**: Create `Makefile` with `run`, `test`, `desktop`, `lint` targets
- **M13 (#82)**: Add `TERMINAL_DATA_DIR`, `TERMINAL_AUTH_TOKEN`, `TERMINAL_CLAUDE_BINARY` to README env-var table
- **Minor6 (#92)**: Update CLAUDE.md milestone table to mark M1/M4 as partial with issue references

## Test plan

- [ ] `cargo check -p terminal-daemon` — passes (verified locally)
- [ ] `cargo test -p terminal-core -p terminal-daemon` — 63/74 pass; 11 git_engine tests fail in this env due to commit signing (pre-existing; CI Docker container will have clean git config)
- [ ] `cd frontend && npx tsc --noEmit --skipLibCheck` — passes (verified)
- [ ] `cd frontend && npm run build` — passes, outputs 380 kB bundle (verified)

https://claude.ai/code/session_01EjdmgcLrkCc3NmKH5g7P2C
EOF
)