### PR TITLE
Fix all opus-labeled issues (C3, C5b, M5b/c, M12, M14, M16, M17, Minor2/3b/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # Terminal Engine — Project Instructions
 
+> **Long-form docs**: [`docs/architecture.md`](./docs/architecture.md) ·
+> [`docs/git-flow.md`](./docs/git-flow.md) ·
+> [`docs/next-steps.md`](./docs/next-steps.md) ·
+> [`docs/bin-cc.md`](./docs/bin-cc.md) (optional shell helper, not the app).
+
 ## Workspace
 
 Three crates in `crates/`:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A desktop application for managing AI coding sessions with git-integrated sandboxing. Each AI run executes in an isolated git worktree, keeping the user's working directory untouched. Sessions, runs, and worktree metadata are persisted to disk with atomic writes and crash recovery.
 
+> **Docs**: [`architecture`](./docs/architecture.md) · [`git-flow`](./docs/git-flow.md) · [`next-steps`](./docs/next-steps.md) · [`bin/cc` helper](./docs/bin-cc.md)
+
 ## Architecture
 
 ```

--- a/crates/terminal-core/src/models.rs
+++ b/crates/terminal-core/src/models.rs
@@ -327,6 +327,12 @@ pub struct WorktreeMeta {
     pub base_head: String,
     pub merge_base: String,
     pub last_modified: DateTime<Utc>,
+    /// Main repository root this worktree belongs to. Needed so cleanup
+    /// paths (crash recovery, startup reconcile) can invoke `git worktree
+    /// remove`. Optional for backward compatibility with older JSON files;
+    /// when absent, callers fall back to deriving it from `worktree_path`.
+    #[serde(default)]
+    pub repo_root: Option<PathBuf>,
 }
 
 // --- Sidebar Types (Phase 3) ---
@@ -594,10 +600,26 @@ mod tests {
             base_head: "abc123".into(),
             merge_base: "abc123".into(),
             last_modified: chrono::Utc::now(),
+            repo_root: Some(PathBuf::from("/tmp/project")),
         };
         let json = serde_json::to_string(&meta).unwrap();
         let deserialized: WorktreeMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.branch_name, "llm/test");
+        assert_eq!(deserialized.repo_root.as_deref(), Some(std::path::Path::new("/tmp/project")));
+    }
+
+    #[test]
+    fn worktree_meta_backward_compat_without_repo_root() {
+        // Older JSON payloads (pre-M17) had no repo_root field.
+        let legacy_json = r#"{
+            "worktree_path": "/tmp/wt",
+            "branch_name": "llm/test",
+            "base_head": "abc123",
+            "merge_base": "abc123",
+            "last_modified": "2024-01-01T00:00:00Z"
+        }"#;
+        let meta: WorktreeMeta = serde_json::from_str(legacy_json).unwrap();
+        assert!(meta.repo_root.is_none());
     }
 
     #[test]

--- a/crates/terminal-core/src/protocol/v1.rs
+++ b/crates/terminal-core/src/protocol/v1.rs
@@ -1060,4 +1060,502 @@ mod tests {
         assert!(json.contains("\"type\":\"PushBranch\""));
         let _: AppCommand = serde_json::from_str(&json).unwrap();
     }
+
+    // --- Exhaustive roundtrip coverage (issue #88, Minor2) ---------------
+    //
+    // These two tests construct one instance of every `AppCommand` /
+    // `AppEvent` variant, serialize and deserialize it, and verify the tag
+    // survives. The inner exhaustive `match` against each enum means adding
+    // a new variant without extending this list fails to compile, which
+    // satisfies the "missing variant fails CI" acceptance criterion.
+
+    fn roundtrip_command(cmd: &AppCommand) -> String {
+        let json = serde_json::to_string(cmd).expect("serialize");
+        let back: AppCommand = serde_json::from_str(&json).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        assert_eq!(json, json2, "roundtrip stability failed for {}", json);
+        json
+    }
+
+    fn roundtrip_event(evt: &AppEvent) -> String {
+        let json = serde_json::to_string(evt).expect("serialize");
+        let back: AppEvent = serde_json::from_str(&json).expect("deserialize");
+        let json2 = serde_json::to_string(&back).expect("re-serialize");
+        assert_eq!(json, json2, "roundtrip stability failed for {}", json);
+        json
+    }
+
+    #[test]
+    fn every_app_command_variant_roundtrips() {
+        let uuid = || Uuid::new_v4();
+        let path = || PathBuf::from("/tmp/x");
+        let commands: Vec<AppCommand> = vec![
+            AppCommand::Auth { token: "tok".into() },
+            AppCommand::StartSession { project_root: path() },
+            AppCommand::EndSession { session_id: uuid() },
+            AppCommand::ListSessions,
+            AppCommand::StartRun {
+                session_id: uuid(),
+                prompt: "p".into(),
+                mode: RunMode::Free,
+                skip_dirty_check: false,
+                autonomy: AutonomyLevel::default(),
+            },
+            AppCommand::CancelRun { run_id: uuid(), reason: "user".into() },
+            AppCommand::RespondToBlocking { run_id: uuid(), response: "ok".into() },
+            AppCommand::GetRunStatus { run_id: uuid() },
+            AppCommand::ListRuns { session_id: uuid() },
+            AppCommand::GetRunOutput { run_id: uuid(), offset: 0, limit: 100 },
+            AppCommand::GetDiff { run_id: uuid() },
+            AppCommand::RevertRun { run_id: uuid() },
+            AppCommand::MergeRun { run_id: uuid() },
+            AppCommand::ListStashes,
+            AppCommand::GetStashFiles { stash_index: 0 },
+            AppCommand::GetStashDiff { stash_index: 0, file_path: None },
+            AppCommand::CheckDirtyState,
+            AppCommand::StashAndRun {
+                session_id: uuid(),
+                prompt: "p".into(),
+                mode: RunMode::Free,
+                stash_message: "m".into(),
+            },
+            AppCommand::ListBranches,
+            AppCommand::ListDirectory { path: path() },
+            AppCommand::GetChangedFiles { mode: "working".into(), run_id: None },
+            AppCommand::GetFileDiff {
+                file_path: path(),
+                mode: "working".into(),
+                run_id: None,
+            },
+            AppCommand::GetRepoStatus,
+            AppCommand::GetCommitHistory { limit: 20 },
+            AppCommand::StageFile { path: path() },
+            AppCommand::UnstageFile { path: path() },
+            AppCommand::CreateCommit { message: "msg".into() },
+            AppCommand::CheckoutBranch { name: "main".into() },
+            AppCommand::CreateBranch { name: "feat".into(), from: Some("main".into()) },
+            AppCommand::ListWorkspaces,
+            AppCommand::CreateWorkspace {
+                name: "w".into(),
+                root_path: path(),
+                mode: WorkspaceMode::AiSession,
+            },
+            AppCommand::CloseWorkspace { workspace_id: uuid() },
+            AppCommand::ActivateWorkspace { workspace_id: uuid() },
+            AppCommand::CreateTerminalSession {
+                workspace_id: uuid(),
+                shell: None,
+                cwd: None,
+                env: None,
+                ssh: None,
+            },
+            AppCommand::CloseTerminalSession { session_id: uuid() },
+            AppCommand::WriteTerminalInput { session_id: uuid(), data: "ls\n".into() },
+            AppCommand::ResizeTerminal { session_id: uuid(), cols: 80, rows: 24 },
+            AppCommand::ListTerminalSessions { workspace_id: uuid() },
+            AppCommand::RestoreTerminalSession {
+                previous_session_id: uuid(),
+                workspace_id: uuid(),
+            },
+            AppCommand::ListRestoredTerminalSessions { workspace_id: uuid() },
+            AppCommand::PushBranch { remote: None, branch: None },
+            AppCommand::PullBranch { remote: None, branch: None },
+            AppCommand::FetchRemote { remote: None },
+            AppCommand::GetMergeConflicts,
+            AppCommand::ResolveConflict {
+                file_path: path(),
+                resolution: ConflictResolution::TakeOurs,
+            },
+            AppCommand::ReadFile { path: "x".into(), max_bytes: None },
+            AppCommand::SearchFiles {
+                query: "q".into(),
+                is_regex: false,
+                case_sensitive: false,
+                include_glob: None,
+                exclude_glob: None,
+                max_results: None,
+                context_lines: None,
+            },
+            AppCommand::GetStatus,
+            AppCommand::Ping,
+        ];
+
+        // Exhaustive match — future variants MUST appear here or compilation
+        // fails, which is exactly the CI gate Minor2 asks for.
+        fn ensure_exhaustive(c: &AppCommand) -> &'static str {
+            match c {
+                AppCommand::Auth { .. } => "Auth",
+                AppCommand::StartSession { .. } => "StartSession",
+                AppCommand::EndSession { .. } => "EndSession",
+                AppCommand::ListSessions => "ListSessions",
+                AppCommand::StartRun { .. } => "StartRun",
+                AppCommand::CancelRun { .. } => "CancelRun",
+                AppCommand::RespondToBlocking { .. } => "RespondToBlocking",
+                AppCommand::GetRunStatus { .. } => "GetRunStatus",
+                AppCommand::ListRuns { .. } => "ListRuns",
+                AppCommand::GetRunOutput { .. } => "GetRunOutput",
+                AppCommand::GetDiff { .. } => "GetDiff",
+                AppCommand::RevertRun { .. } => "RevertRun",
+                AppCommand::MergeRun { .. } => "MergeRun",
+                AppCommand::ListStashes => "ListStashes",
+                AppCommand::GetStashFiles { .. } => "GetStashFiles",
+                AppCommand::GetStashDiff { .. } => "GetStashDiff",
+                AppCommand::CheckDirtyState => "CheckDirtyState",
+                AppCommand::StashAndRun { .. } => "StashAndRun",
+                AppCommand::ListBranches => "ListBranches",
+                AppCommand::ListDirectory { .. } => "ListDirectory",
+                AppCommand::GetChangedFiles { .. } => "GetChangedFiles",
+                AppCommand::GetFileDiff { .. } => "GetFileDiff",
+                AppCommand::GetRepoStatus => "GetRepoStatus",
+                AppCommand::GetCommitHistory { .. } => "GetCommitHistory",
+                AppCommand::StageFile { .. } => "StageFile",
+                AppCommand::UnstageFile { .. } => "UnstageFile",
+                AppCommand::CreateCommit { .. } => "CreateCommit",
+                AppCommand::CheckoutBranch { .. } => "CheckoutBranch",
+                AppCommand::CreateBranch { .. } => "CreateBranch",
+                AppCommand::ListWorkspaces => "ListWorkspaces",
+                AppCommand::CreateWorkspace { .. } => "CreateWorkspace",
+                AppCommand::CloseWorkspace { .. } => "CloseWorkspace",
+                AppCommand::ActivateWorkspace { .. } => "ActivateWorkspace",
+                AppCommand::CreateTerminalSession { .. } => "CreateTerminalSession",
+                AppCommand::CloseTerminalSession { .. } => "CloseTerminalSession",
+                AppCommand::WriteTerminalInput { .. } => "WriteTerminalInput",
+                AppCommand::ResizeTerminal { .. } => "ResizeTerminal",
+                AppCommand::ListTerminalSessions { .. } => "ListTerminalSessions",
+                AppCommand::RestoreTerminalSession { .. } => "RestoreTerminalSession",
+                AppCommand::ListRestoredTerminalSessions { .. } => "ListRestoredTerminalSessions",
+                AppCommand::PushBranch { .. } => "PushBranch",
+                AppCommand::PullBranch { .. } => "PullBranch",
+                AppCommand::FetchRemote { .. } => "FetchRemote",
+                AppCommand::GetMergeConflicts => "GetMergeConflicts",
+                AppCommand::ResolveConflict { .. } => "ResolveConflict",
+                AppCommand::ReadFile { .. } => "ReadFile",
+                AppCommand::SearchFiles { .. } => "SearchFiles",
+                AppCommand::GetStatus => "GetStatus",
+                AppCommand::Ping => "Ping",
+            }
+        }
+
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        for cmd in &commands {
+            let tag = ensure_exhaustive(cmd);
+            seen.insert(tag);
+            let json = roundtrip_command(cmd);
+            assert!(
+                json.contains(&format!("\"type\":\"{}\"", tag)),
+                "expected tag {} in {}",
+                tag,
+                json
+            );
+        }
+        // Sanity-check the table covers every tag the exhaustive match knows.
+        assert_eq!(
+            seen.len(),
+            commands.len(),
+            "duplicate or missing variant in commands list"
+        );
+    }
+
+    #[test]
+    fn every_app_event_variant_roundtrips() {
+        let uuid = || Uuid::new_v4();
+        let path = || PathBuf::from("/tmp/x");
+        let diff_stat = || DiffStat {
+            files_changed: 0,
+            insertions: 0,
+            deletions: 0,
+            file_stats: vec![],
+        };
+        let events: Vec<AppEvent> = vec![
+            AppEvent::AuthSuccess,
+            AppEvent::AuthFailed { reason: "bad".into() },
+            AppEvent::RunStateChanged {
+                run_id: uuid(),
+                new_state: RunState::Running,
+            },
+            AppEvent::RunOutput {
+                run_id: uuid(),
+                line: "x".into(),
+                line_number: 1,
+            },
+            AppEvent::RunBlocking {
+                run_id: uuid(),
+                question: "?".into(),
+                context: vec![],
+            },
+            AppEvent::RunCompleted {
+                run_id: uuid(),
+                summary: RunSummary {
+                    id: uuid(),
+                    state: RunState::Completed { exit_code: 0 },
+                    prompt_preview: "p".into(),
+                    modified_file_count: 0,
+                    diff_stat: None,
+                    started_at: chrono::Utc::now(),
+                    ended_at: None,
+                    autonomy: AutonomyLevel::default(),
+                },
+                diff_stat: None,
+            },
+            AppEvent::RunFailed {
+                run_id: uuid(),
+                error: "e".into(),
+                phase: FailPhase::Execution,
+            },
+            AppEvent::RunCancelled { run_id: uuid() },
+            AppEvent::RunToolUse {
+                run_id: uuid(),
+                tool_id: "t".into(),
+                tool_name: "Edit".into(),
+                tool_input_preview: "x".into(),
+            },
+            AppEvent::RunToolResult {
+                run_id: uuid(),
+                tool_id: "t".into(),
+                is_error: false,
+                preview: "ok".into(),
+            },
+            AppEvent::RunMetrics {
+                run_id: uuid(),
+                num_turns: 1,
+                cost_usd: 0.1,
+                input_tokens: 1,
+                output_tokens: 1,
+            },
+            AppEvent::RunPreflightFailed {
+                run_id: uuid(),
+                reason: "r".into(),
+                suggestion: "s".into(),
+            },
+            AppEvent::RunDiff {
+                run_id: uuid(),
+                stat: diff_stat(),
+                diff: "".into(),
+            },
+            AppEvent::RunReverted { run_id: uuid() },
+            AppEvent::RunMerged {
+                run_id: uuid(),
+                merge_result: MergeResult::FastForward,
+            },
+            AppEvent::RunMergeConflict {
+                run_id: uuid(),
+                conflict_paths: vec![path()],
+            },
+            AppEvent::StashList { stashes: vec![] },
+            AppEvent::StashFiles { stash_index: 0, files: vec![] },
+            AppEvent::StashDiff {
+                stash_index: 0,
+                diff: "".into(),
+                stat: None,
+            },
+            AppEvent::DirtyState {
+                status: DirtyStatus { staged: vec![], unstaged: vec![] },
+            },
+            AppEvent::DirtyWarning {
+                status: DirtyStatus { staged: vec![], unstaged: vec![] },
+                session_id: uuid(),
+                prompt: "p".into(),
+                mode: RunMode::Free,
+            },
+            AppEvent::DirectoryListing { path: path(), entries: vec![] },
+            AppEvent::ChangedFilesList {
+                mode: "working".into(),
+                run_id: None,
+                files: vec![],
+            },
+            AppEvent::FileDiffResult {
+                file_path: path(),
+                diff: "".into(),
+                stat: None,
+            },
+            AppEvent::RepoStatusResult {
+                status: RepoStatusSnapshot {
+                    branch: "main".into(),
+                    head: "abc123".into(),
+                    clean: true,
+                    staged_count: 0,
+                    unstaged_count: 0,
+                },
+            },
+            AppEvent::CommitHistoryResult { commits: vec![] },
+            AppEvent::CommitCreated { hash: "abc".into() },
+            AppEvent::BranchChanged { name: "main".into() },
+            AppEvent::BranchList { branches: vec![], current: None },
+            AppEvent::SessionStarted {
+                session: SessionSummary {
+                    id: uuid(),
+                    project_root: path(),
+                    active_run: None,
+                    run_count: 0,
+                    started_at: chrono::Utc::now(),
+                },
+            },
+            AppEvent::SessionEnded { session_id: uuid() },
+            AppEvent::SessionList { sessions: vec![] },
+            AppEvent::RunList { session_id: uuid(), runs: vec![] },
+            AppEvent::RunOutputPage {
+                run_id: uuid(),
+                offset: 0,
+                lines: vec![],
+                has_more: false,
+            },
+            AppEvent::WorkspaceList { workspaces: vec![] },
+            AppEvent::WorkspaceCreated {
+                workspace: WorkspaceSummary {
+                    id: uuid(),
+                    name: "w".into(),
+                    root_path: path(),
+                    mode: WorkspaceMode::AiSession,
+                    linked_session_id: None,
+                    last_active_at: chrono::Utc::now(),
+                },
+            },
+            AppEvent::WorkspaceClosed { workspace_id: uuid() },
+            AppEvent::WorkspaceActivated { workspace_id: uuid() },
+            AppEvent::TerminalSessionCreated {
+                session_id: uuid(),
+                workspace_id: uuid(),
+                shell: "sh".into(),
+                cwd: path(),
+                is_ssh: false,
+                ssh_host: None,
+            },
+            AppEvent::TerminalSessionClosed { session_id: uuid() },
+            AppEvent::TerminalOutput { session_id: uuid(), data: "x".into() },
+            AppEvent::TerminalSessionList {
+                workspace_id: uuid(),
+                sessions: vec![],
+            },
+            AppEvent::TerminalSessionRestored {
+                previous_session_id: uuid(),
+                new_session_id: uuid(),
+                cwd: path(),
+                workspace_id: uuid(),
+            },
+            AppEvent::TerminalSessionRestoreFailed {
+                previous_session_id: uuid(),
+                reason: "r".into(),
+            },
+            AppEvent::RestorableTerminalSessions {
+                workspace_id: uuid(),
+                sessions: vec![],
+            },
+            AppEvent::PushCompleted {
+                branch: "main".into(),
+                remote: "origin".into(),
+            },
+            AppEvent::PullCompleted {
+                branch: "main".into(),
+                commits_applied: 0,
+            },
+            AppEvent::FetchCompleted { remote: "origin".into() },
+            AppEvent::GitOperationFailed {
+                operation: "push".into(),
+                reason: "r".into(),
+            },
+            AppEvent::MergeConflicts { files: vec![] },
+            AppEvent::ConflictResolved { file_path: path() },
+            AppEvent::FileContent {
+                path: "x".into(),
+                content: "y".into(),
+                language: "rust".into(),
+                truncated: false,
+                size_bytes: 0,
+            },
+            AppEvent::FileReadError { path: "x".into(), error: "e".into() },
+            AppEvent::SearchResults {
+                query: "q".into(),
+                matches: vec![],
+                total_matches: 0,
+                files_searched: 0,
+                truncated: false,
+                duration_ms: 0,
+            },
+            AppEvent::StatusUpdate { active_runs: 0, session_count: 0 },
+            AppEvent::Pong,
+            AppEvent::Error { code: "c".into(), message: "m".into() },
+        ];
+
+        fn ensure_exhaustive(e: &AppEvent) -> &'static str {
+            match e {
+                AppEvent::AuthSuccess => "AuthSuccess",
+                AppEvent::AuthFailed { .. } => "AuthFailed",
+                AppEvent::RunStateChanged { .. } => "RunStateChanged",
+                AppEvent::RunOutput { .. } => "RunOutput",
+                AppEvent::RunBlocking { .. } => "RunBlocking",
+                AppEvent::RunCompleted { .. } => "RunCompleted",
+                AppEvent::RunFailed { .. } => "RunFailed",
+                AppEvent::RunCancelled { .. } => "RunCancelled",
+                AppEvent::RunToolUse { .. } => "RunToolUse",
+                AppEvent::RunToolResult { .. } => "RunToolResult",
+                AppEvent::RunMetrics { .. } => "RunMetrics",
+                AppEvent::RunPreflightFailed { .. } => "RunPreflightFailed",
+                AppEvent::RunDiff { .. } => "RunDiff",
+                AppEvent::RunReverted { .. } => "RunReverted",
+                AppEvent::RunMerged { .. } => "RunMerged",
+                AppEvent::RunMergeConflict { .. } => "RunMergeConflict",
+                AppEvent::StashList { .. } => "StashList",
+                AppEvent::StashFiles { .. } => "StashFiles",
+                AppEvent::StashDiff { .. } => "StashDiff",
+                AppEvent::DirtyState { .. } => "DirtyState",
+                AppEvent::DirtyWarning { .. } => "DirtyWarning",
+                AppEvent::DirectoryListing { .. } => "DirectoryListing",
+                AppEvent::ChangedFilesList { .. } => "ChangedFilesList",
+                AppEvent::FileDiffResult { .. } => "FileDiffResult",
+                AppEvent::RepoStatusResult { .. } => "RepoStatusResult",
+                AppEvent::CommitHistoryResult { .. } => "CommitHistoryResult",
+                AppEvent::CommitCreated { .. } => "CommitCreated",
+                AppEvent::BranchChanged { .. } => "BranchChanged",
+                AppEvent::BranchList { .. } => "BranchList",
+                AppEvent::SessionStarted { .. } => "SessionStarted",
+                AppEvent::SessionEnded { .. } => "SessionEnded",
+                AppEvent::SessionList { .. } => "SessionList",
+                AppEvent::RunList { .. } => "RunList",
+                AppEvent::RunOutputPage { .. } => "RunOutputPage",
+                AppEvent::WorkspaceList { .. } => "WorkspaceList",
+                AppEvent::WorkspaceCreated { .. } => "WorkspaceCreated",
+                AppEvent::WorkspaceClosed { .. } => "WorkspaceClosed",
+                AppEvent::WorkspaceActivated { .. } => "WorkspaceActivated",
+                AppEvent::TerminalSessionCreated { .. } => "TerminalSessionCreated",
+                AppEvent::TerminalSessionClosed { .. } => "TerminalSessionClosed",
+                AppEvent::TerminalOutput { .. } => "TerminalOutput",
+                AppEvent::TerminalSessionList { .. } => "TerminalSessionList",
+                AppEvent::TerminalSessionRestored { .. } => "TerminalSessionRestored",
+                AppEvent::TerminalSessionRestoreFailed { .. } => "TerminalSessionRestoreFailed",
+                AppEvent::RestorableTerminalSessions { .. } => "RestorableTerminalSessions",
+                AppEvent::PushCompleted { .. } => "PushCompleted",
+                AppEvent::PullCompleted { .. } => "PullCompleted",
+                AppEvent::FetchCompleted { .. } => "FetchCompleted",
+                AppEvent::GitOperationFailed { .. } => "GitOperationFailed",
+                AppEvent::MergeConflicts { .. } => "MergeConflicts",
+                AppEvent::ConflictResolved { .. } => "ConflictResolved",
+                AppEvent::FileContent { .. } => "FileContent",
+                AppEvent::FileReadError { .. } => "FileReadError",
+                AppEvent::SearchResults { .. } => "SearchResults",
+                AppEvent::StatusUpdate { .. } => "StatusUpdate",
+                AppEvent::Pong => "Pong",
+                AppEvent::Error { .. } => "Error",
+            }
+        }
+
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        for evt in &events {
+            let tag = ensure_exhaustive(evt);
+            seen.insert(tag);
+            let json = roundtrip_event(evt);
+            assert!(
+                json.contains(&format!("\"type\":\"{}\"", tag)),
+                "expected tag {} in {}",
+                tag,
+                json
+            );
+        }
+        assert_eq!(
+            seen.len(),
+            events.len(),
+            "duplicate or missing variant in events list"
+        );
+    }
 }

--- a/crates/terminal-daemon/src/daemon_context.rs
+++ b/crates/terminal-daemon/src/daemon_context.rs
@@ -32,8 +32,9 @@ pub struct DaemonContext {
     pub runner: Arc<ClaudeRunner>,
     /// Workspaces registry (M1-05)
     pub workspaces: Arc<Mutex<HashMap<Uuid, Workspace>>>,
-    /// Active workspace id per client (simplified: global for now)
-    pub active_workspace_id: Arc<Mutex<Option<Uuid>>>,
+    /// Per-client active workspace map (M5b, issue #100).
+    /// client_id -> workspace_id. Removed on client disconnect by the WS handler.
+    pub active_workspaces: Arc<Mutex<HashMap<Uuid, Uuid>>>,
     /// Workspace-scoped broadcast channels (M1-05)
     pub workspace_channels: Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>,
 }
@@ -54,7 +55,7 @@ impl DaemonContext {
             concurrency: Arc::new(Mutex::new(HashMap::new())),
             runner,
             workspaces: Arc::new(Mutex::new(HashMap::new())),
-            active_workspace_id: Arc::new(Mutex::new(None)),
+            active_workspaces: Arc::new(Mutex::new(HashMap::new())),
             workspace_channels: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -64,7 +65,9 @@ impl DaemonContext {
         broadcast_event(&self.event_tx, event);
     }
 
-    /// Broadcast an event to a specific workspace channel, falling back to global.
+    /// Broadcast an event to a specific workspace channel. Falls back to the
+    /// global channel if the workspace is unknown — typically a race during
+    /// close/restart. A warning is logged so we notice leaks (M5c).
     pub async fn broadcast_workspace(&self, workspace_id: Uuid, event: &AppEvent) {
         match serde_json::to_string(event) {
             Ok(json) => {
@@ -72,6 +75,11 @@ impl DaemonContext {
                 if let Some(tx) = channels.get(&workspace_id) {
                     let _ = tx.send(json);
                 } else {
+                    tracing::warn!(
+                        "broadcast_workspace: no channel for workspace {}, \
+                         falling back to global (likely a close/create race)",
+                        workspace_id,
+                    );
                     let _ = self.event_tx.send(json);
                 }
             }
@@ -109,5 +117,55 @@ impl DaemonContext {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_ctx(tmp: &TempDir) -> Arc<DaemonContext> {
+        let cfg = DaemonConfig {
+            data_dir: tmp.path().to_path_buf(),
+            ..Default::default()
+        };
+        let (tx, _) = broadcast::channel::<String>(64);
+        let persistence = Arc::new(Persistence::new(tmp.path().to_path_buf()).unwrap());
+        Arc::new(DaemonContext::new(cfg, tx, persistence))
+    }
+
+    #[tokio::test]
+    async fn broadcast_workspace_only_reaches_subscribed_client() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = make_ctx(&tmp);
+        let ws_a = Uuid::new_v4();
+        let ws_b = Uuid::new_v4();
+        let (tx_a, mut rx_a) = broadcast::channel::<String>(16);
+        let (tx_b, mut rx_b) = broadcast::channel::<String>(16);
+        ctx.workspace_channels.lock().await.insert(ws_a, tx_a);
+        ctx.workspace_channels.lock().await.insert(ws_b, tx_b);
+
+        ctx.broadcast_workspace(ws_a, &AppEvent::AuthSuccess).await;
+
+        let msg_a = rx_a.recv().await.expect("ws_a should receive");
+        assert!(msg_a.contains("AuthSuccess"));
+        assert!(
+            rx_b.try_recv().is_err(),
+            "ws_b should NOT receive events targeted at ws_a"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_workspace_falls_back_to_global_when_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = make_ctx(&tmp);
+        let mut global_rx = ctx.event_tx.subscribe();
+
+        ctx.broadcast_workspace(Uuid::new_v4(), &AppEvent::AuthSuccess)
+            .await;
+
+        let msg = global_rx.recv().await.expect("global fallback");
+        assert!(msg.contains("AuthSuccess"));
     }
 }

--- a/crates/terminal-daemon/src/dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatcher.rs
@@ -1,5 +1,6 @@
 use crate::claude_runner::{output_file_path, RunnerEvent};
 use crate::daemon_context::{ActiveRun, DaemonContext};
+use crate::guards::ConcurrencyGuard;
 use crate::persistence::Persistence;
 use crate::pty::PtyManager;
 use crate::safety::broadcast_event;
@@ -25,7 +26,9 @@ impl Dispatcher {
         persistence: Arc<Persistence>,
     ) -> Self {
         let context = Arc::new(DaemonContext::new(config, event_tx.clone(), persistence));
-        let pty_manager = Arc::new(PtyManager::new(event_tx));
+        let pty_manager = Arc::new(
+            PtyManager::new(event_tx).with_workspace_channels(context.workspace_channels.clone()),
+        );
         Self { context, pty_manager }
     }
 
@@ -34,8 +37,43 @@ impl Dispatcher {
         self.context.broadcast(event);
     }
 
+    /// Load persisted workspaces from disk into the in-memory registry and
+    /// create a broadcast channel for each. Called once at startup (C5b,
+    /// issue #98).
+    pub async fn recover_workspaces(&self) {
+        let persisted = match self.context.persistence.list_workspaces() {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("recover_workspaces: list failed: {}", e);
+                return;
+            }
+        };
+        if persisted.is_empty() {
+            return;
+        }
+        let mut workspaces = self.context.workspaces.lock().await;
+        let mut channels = self.context.workspace_channels.lock().await;
+        for ws in persisted {
+            let id = ws.id;
+            channels.entry(id).or_insert_with(|| broadcast::channel(512).0);
+            workspaces.insert(id, ws);
+        }
+        info!("Recovered {} persisted workspace(s)", workspaces.len());
+    }
+
+    /// Borrow the shared daemon context (used by `server.rs` to reach
+    /// per-client state like `active_workspaces`).
+    pub fn context(&self) -> Arc<DaemonContext> {
+        self.context.clone()
+    }
+
     /// Handle a command and send response to the requesting client.
-    pub async fn handle(&self, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
+    pub async fn handle(
+        &self,
+        cmd: AppCommand,
+        client_id: Uuid,
+        reply_tx: mpsc::Sender<AppEvent>,
+    ) {
         match cmd {
             AppCommand::Auth { .. } => {
                 // Auth is handled at the server level, not here
@@ -1127,7 +1165,7 @@ impl Dispatcher {
                 let dispatcher = crate::dispatchers::workspace_dispatcher::WorkspaceDispatcher::new(
                     self.context.clone(),
                 );
-                dispatcher.handle(cmd, reply_tx).await;
+                dispatcher.handle(cmd, client_id, reply_tx).await;
             }
 
             // --- PTY commands (M4-01) ---
@@ -1298,30 +1336,38 @@ impl Dispatcher {
         let mut base_head = String::new();
         let mut actual_working_dir = project_root.clone();
 
+        // RAII concurrency guard — dropped on early return, `forget()` once
+        // the supervisor task takes ownership of cleanup on successful spawn.
+        let mut concurrency_guard: Option<ConcurrencyGuard> = None;
+
         if is_git {
-            // Check concurrency: lock -> check -> insert -> unlock (no await gap)
+            // Concurrency guard (see crate::guards): removes the entry on
+            // any early return below without manual cleanup.
+            let guard = match ConcurrencyGuard::acquire(
+                self.context.concurrency.clone(),
+                project_root.clone(),
+                run_id,
+            )
+            .await
             {
-                let mut conc = self.context.concurrency.lock().await;
-                if let Some(existing_run_id) = conc.get(&project_root) {
+                Some(g) => g,
+                None => {
                     let _ = reply_tx
                         .send(AppEvent::Error {
                             code: "REPO_BUSY".into(),
                             message: format!(
-                                "Repository {} already has active run {}",
-                                project_root.display(),
-                                existing_run_id
+                                "Repository {} already has an active run",
+                                project_root.display()
                             ),
                         })
                         .await;
                     return;
                 }
-                conc.insert(project_root.clone(), run_id);
-            }
+            };
+            concurrency_guard = Some(guard);
 
             // Guard repo state
             if let Err(e) = crate::git_engine::guard_repo_state(&project_root).await {
-                // Cleanup concurrency
-                self.context.concurrency.lock().await.remove(&project_root);
                 let _ = reply_tx
                     .send(AppEvent::Error {
                         code: "GIT_STATE_ERROR".into(),
@@ -1341,8 +1387,6 @@ impl Dispatcher {
                     });
 
                 if !dirty.staged.is_empty() || !dirty.unstaged.is_empty() {
-                    // Release concurrency lock before returning
-                    self.context.concurrency.lock().await.remove(&project_root);
                     // Send DirtyWarning event -- frontend will show modal
                     let _ = reply_tx
                         .send(AppEvent::DirtyWarning {
@@ -1360,7 +1404,6 @@ impl Dispatcher {
             match crate::git_engine::head_oid(&project_root).await {
                 Ok(oid) => base_head = oid,
                 Err(e) => {
-                    self.context.concurrency.lock().await.remove(&project_root);
                     let _ = reply_tx
                         .send(AppEvent::Error {
                             code: "GIT_ERROR".into(),
@@ -1381,7 +1424,6 @@ impl Dispatcher {
             let wt_parent = match wt_path.parent() {
                 Some(p) => p,
                 None => {
-                    self.context.concurrency.lock().await.remove(&project_root);
                     let _ = reply_tx
                         .send(AppEvent::Error {
                             code: "IO_ERROR".into(),
@@ -1392,7 +1434,6 @@ impl Dispatcher {
                 }
             };
             if let Err(e) = tokio::fs::create_dir_all(wt_parent).await {
-                self.context.concurrency.lock().await.remove(&project_root);
                 let _ = reply_tx
                     .send(AppEvent::Error {
                         code: "IO_ERROR".into(),
@@ -1404,7 +1445,6 @@ impl Dispatcher {
 
             // Create worktree
             if let Err(e) = crate::git_engine::worktree_add(&project_root, &wt_path, &branch_name).await {
-                self.context.concurrency.lock().await.remove(&project_root);
                 let _ = reply_tx
                     .send(AppEvent::Error {
                         code: "GIT_ERROR".into(),
@@ -1421,6 +1461,7 @@ impl Dispatcher {
                 base_head: base_head.clone(),
                 merge_base: base_head.clone(),
                 last_modified: chrono::Utc::now(),
+                repo_root: Some(project_root.clone()),
             };
             if let Err(e) = self.context.persistence.save_worktree_meta(run_id, &meta) {
                 warn!("Failed to persist worktree meta for run {}: {}", run_id, e);
@@ -1495,9 +1536,14 @@ impl Dispatcher {
             return;
         }
 
-        // Spawn claude process in actual_working_dir (worktree if git)
+        // Spawn claude process in actual_working_dir (worktree if git).
+        // Ownership of the concurrency entry transfers to the supervisor task
+        // on success; `forget()` prevents the guard from clearing it on drop.
         match self.context.runner.spawn(run_id, &prompt, &mode, autonomy, &actual_working_dir) {
             Ok((mut event_rx, stdin_tx, mut child)) => {
+                if let Some(g) = concurrency_guard.take() {
+                    g.forget();
+                }
                 let (cancel_tx, mut cancel_rx) = mpsc::channel::<String>(1);
 
                 let active_run = ActiveRun {
@@ -1824,9 +1870,9 @@ impl Dispatcher {
                 if let Some(session) = sessions.get_mut(&session_id) {
                     session.active_run = None;
                 }
-                // Cleanup concurrency and worktree on spawn failure
+                // Concurrency entry is released automatically when
+                // `concurrency_guard` drops at end of scope.
                 if is_git {
-                    self.context.concurrency.lock().await.remove(&project_root);
                     if let Some(ref wt_path) = worktree_path {
                         if let Err(e) = crate::git_engine::worktree_remove(&project_root, wt_path).await {
                             warn!("Failed to cleanup worktree on spawn failure: {}", e);

--- a/crates/terminal-daemon/src/dispatchers/workspace_dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatchers/workspace_dispatcher.rs
@@ -17,7 +17,12 @@ impl WorkspaceDispatcher {
         Self { ctx }
     }
 
-    pub async fn handle(&self, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
+    pub async fn handle(
+        &self,
+        cmd: AppCommand,
+        client_id: Uuid,
+        reply_tx: mpsc::Sender<AppEvent>,
+    ) {
         match cmd {
             AppCommand::ListWorkspaces => {
                 let workspaces = self.ctx.workspaces.lock().await;
@@ -54,6 +59,12 @@ impl WorkspaceDispatcher {
                 self.ctx.workspace_channels.lock().await.insert(id, ws_tx);
 
                 let summary = WorkspaceSummary::from(&ws);
+
+                // Persist before registering in-memory so a crash doesn't leave a
+                // ghost workspace that can't be recovered (C5b, issue #98).
+                if let Err(e) = self.ctx.persistence.save_workspace(&ws) {
+                    warn!("Failed to persist workspace {}: {}", id, e);
+                }
                 self.ctx.workspaces.lock().await.insert(id, ws);
 
                 info!("Workspace created: {} ({:?}) at {}", id, mode, root_path.display());
@@ -69,6 +80,14 @@ impl WorkspaceDispatcher {
                 if removed.is_some() {
                     // Remove workspace channel
                     self.ctx.workspace_channels.lock().await.remove(&workspace_id);
+                    // Scrub every client's active pointer that targeted this one (M5b).
+                    {
+                        let mut active = self.ctx.active_workspaces.lock().await;
+                        active.retain(|_, wid| *wid != workspace_id);
+                    }
+                    if let Err(e) = self.ctx.persistence.delete_workspace(workspace_id) {
+                        warn!("Failed to delete persisted workspace {}: {}", workspace_id, e);
+                    }
                     info!("Workspace closed: {}", workspace_id);
                     self.ctx.broadcast(&AppEvent::WorkspaceClosed { workspace_id });
                     let _ = reply_tx
@@ -85,10 +104,23 @@ impl WorkspaceDispatcher {
             }
 
             AppCommand::ActivateWorkspace { workspace_id } => {
-                let exists = self.ctx.workspaces.lock().await.contains_key(&workspace_id);
-                if exists {
-                    *self.ctx.active_workspace_id.lock().await = Some(workspace_id);
-                    self.ctx.broadcast(&AppEvent::WorkspaceActivated { workspace_id });
+                let updated_ws = {
+                    let mut map = self.ctx.workspaces.lock().await;
+                    map.get_mut(&workspace_id).map(|ws| {
+                        ws.last_active_at = chrono::Utc::now();
+                        ws.clone()
+                    })
+                };
+                if let Some(ws) = updated_ws {
+                    self.ctx
+                        .active_workspaces
+                        .lock()
+                        .await
+                        .insert(client_id, workspace_id);
+                    if let Err(e) = self.ctx.persistence.save_workspace(&ws) {
+                        warn!("Failed to persist workspace activation {}: {}", workspace_id, e);
+                    }
+                    // M5c: WorkspaceActivated is per-client — never broadcast.
                     let _ = reply_tx
                         .send(AppEvent::WorkspaceActivated { workspace_id })
                         .await;
@@ -106,5 +138,170 @@ impl WorkspaceDispatcher {
                 warn!("WorkspaceDispatcher received non-workspace command");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::Persistence;
+    use std::path::PathBuf;
+    use terminal_core::config::DaemonConfig;
+    use terminal_core::models::WorkspaceMode;
+    use tempfile::TempDir;
+
+    fn make_ctx(tmp: &TempDir) -> Arc<DaemonContext> {
+        let config = DaemonConfig {
+            data_dir: tmp.path().to_path_buf(),
+            ..Default::default()
+        };
+        let (tx, _) = broadcast::channel::<String>(64);
+        let persistence = Arc::new(Persistence::new(tmp.path().to_path_buf()).unwrap());
+        Arc::new(DaemonContext::new(config, tx, persistence))
+    }
+
+    #[tokio::test]
+    async fn create_workspace_persists_to_disk() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = make_ctx(&tmp);
+        let dispatcher = WorkspaceDispatcher::new(ctx.clone());
+        let (tx, _rx) = mpsc::channel(8);
+
+        dispatcher
+            .handle(
+                AppCommand::CreateWorkspace {
+                    name: "demo".into(),
+                    root_path: PathBuf::from("/tmp/demo"),
+                    mode: WorkspaceMode::Terminal,
+                },
+                Uuid::new_v4(),
+                tx,
+            )
+            .await;
+
+        let persisted = ctx.persistence.list_workspaces().unwrap();
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].name, "demo");
+    }
+
+    #[tokio::test]
+    async fn close_workspace_removes_from_disk() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = make_ctx(&tmp);
+        let dispatcher = WorkspaceDispatcher::new(ctx.clone());
+        let (tx, _rx) = mpsc::channel(8);
+        let client = Uuid::new_v4();
+
+        dispatcher
+            .handle(
+                AppCommand::CreateWorkspace {
+                    name: "demo".into(),
+                    root_path: PathBuf::from("/tmp/demo"),
+                    mode: WorkspaceMode::Terminal,
+                },
+                client,
+                tx.clone(),
+            )
+            .await;
+
+        let id = *ctx.workspaces.lock().await.keys().next().unwrap();
+        dispatcher
+            .handle(AppCommand::CloseWorkspace { workspace_id: id }, client, tx)
+            .await;
+
+        assert!(ctx.persistence.list_workspaces().unwrap().is_empty());
+        assert!(!ctx.workspaces.lock().await.contains_key(&id));
+    }
+
+    #[tokio::test]
+    async fn two_clients_have_independent_active_workspaces() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = make_ctx(&tmp);
+        let dispatcher = WorkspaceDispatcher::new(ctx.clone());
+        let (tx, _rx) = mpsc::channel(32);
+
+        // Create two workspaces
+        dispatcher
+            .handle(
+                AppCommand::CreateWorkspace {
+                    name: "X".into(),
+                    root_path: PathBuf::from("/tmp/x"),
+                    mode: WorkspaceMode::Terminal,
+                },
+                Uuid::new_v4(),
+                tx.clone(),
+            )
+            .await;
+        dispatcher
+            .handle(
+                AppCommand::CreateWorkspace {
+                    name: "Y".into(),
+                    root_path: PathBuf::from("/tmp/y"),
+                    mode: WorkspaceMode::Terminal,
+                },
+                Uuid::new_v4(),
+                tx.clone(),
+            )
+            .await;
+
+        let ids: Vec<_> = ctx.workspaces.lock().await.keys().copied().collect();
+        let (x_id, y_id) = (ids[0], ids[1]);
+        let client_a = Uuid::new_v4();
+        let client_b = Uuid::new_v4();
+
+        dispatcher
+            .handle(
+                AppCommand::ActivateWorkspace { workspace_id: x_id },
+                client_a,
+                tx.clone(),
+            )
+            .await;
+        dispatcher
+            .handle(
+                AppCommand::ActivateWorkspace { workspace_id: y_id },
+                client_b,
+                tx.clone(),
+            )
+            .await;
+
+        let active = ctx.active_workspaces.lock().await;
+        assert_eq!(active.get(&client_a), Some(&x_id));
+        assert_eq!(active.get(&client_b), Some(&y_id));
+    }
+
+    #[tokio::test]
+    async fn closing_workspace_scrubs_active_entries_for_all_clients() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = make_ctx(&tmp);
+        let dispatcher = WorkspaceDispatcher::new(ctx.clone());
+        let (tx, _rx) = mpsc::channel(32);
+
+        dispatcher
+            .handle(
+                AppCommand::CreateWorkspace {
+                    name: "demo".into(),
+                    root_path: PathBuf::from("/tmp/demo"),
+                    mode: WorkspaceMode::Terminal,
+                },
+                Uuid::new_v4(),
+                tx.clone(),
+            )
+            .await;
+        let id = *ctx.workspaces.lock().await.keys().next().unwrap();
+
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        dispatcher
+            .handle(AppCommand::ActivateWorkspace { workspace_id: id }, a, tx.clone())
+            .await;
+        dispatcher
+            .handle(AppCommand::ActivateWorkspace { workspace_id: id }, b, tx.clone())
+            .await;
+        assert_eq!(ctx.active_workspaces.lock().await.len(), 2);
+
+        dispatcher
+            .handle(AppCommand::CloseWorkspace { workspace_id: id }, a, tx)
+            .await;
+        assert!(ctx.active_workspaces.lock().await.is_empty());
     }
 }

--- a/crates/terminal-daemon/src/guards.rs
+++ b/crates/terminal-daemon/src/guards.rs
@@ -1,0 +1,176 @@
+//! RAII guards for daemon-wide concurrency maps (issue #103, Minor3b).
+//!
+//! `do_start_run` registers the run in two shared maps (concurrency by
+//! project root, active runs by session uuid) and used to remove entries by
+//! hand on every early-return path. That is fragile — missing a cleanup
+//! site leaks the entry forever and permanently blocks the repo.
+//!
+//! These guards own the map key and drop it automatically on scope exit.
+//! `DaemonContext` stores the maps behind a `tokio::sync::Mutex`, so `Drop`
+//! can't `.await`. We spawn a tiny removal task instead; contention is
+//! minimal (insert/remove only) and the spawn cost is negligible.
+//!
+//! Usage:
+//! ```ignore
+//! let Some(_concurrency) =
+//!     ConcurrencyGuard::acquire(ctx.concurrency.clone(), project_root.clone(), run_id).await
+//! else {
+//!     // already in use — emit error and return; no manual cleanup needed
+//! };
+//! // ...early returns are safe; the guard drops and removes the entry.
+//! ```
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+/// Generic RAII guard that removes `key` from `map` on drop.
+pub struct MapKeyGuard<K, V>
+where
+    K: Eq + Hash + Clone + Send + 'static,
+    V: Send + 'static,
+{
+    map: Arc<Mutex<HashMap<K, V>>>,
+    key: Option<K>,
+}
+
+impl<K, V> MapKeyGuard<K, V>
+where
+    K: Eq + Hash + Clone + Send + 'static,
+    V: Send + 'static,
+{
+    /// Try to insert `(key, value)`. Returns `None` if the key already exists
+    /// (caller should report a conflict error and bail). On success, the
+    /// returned guard removes the key when dropped.
+    pub async fn acquire(map: Arc<Mutex<HashMap<K, V>>>, key: K, value: V) -> Option<Self> {
+        let mut m = map.lock().await;
+        if m.contains_key(&key) {
+            return None;
+        }
+        m.insert(key.clone(), value);
+        drop(m);
+        Some(Self {
+            map,
+            key: Some(key),
+        })
+    }
+
+    /// Release the guard without removing the map entry. Used when ownership
+    /// of the entry has transferred elsewhere (e.g. the spawned supervisor
+    /// task that removes it when the run finishes).
+    pub fn forget(mut self) {
+        self.key.take();
+    }
+}
+
+impl<K, V> Drop for MapKeyGuard<K, V>
+where
+    K: Eq + Hash + Clone + Send + 'static,
+    V: Send + 'static,
+{
+    fn drop(&mut self) {
+        if let Some(key) = self.key.take() {
+            let map = self.map.clone();
+            // Drop runs on any thread; spawn the removal so we don't block
+            // the caller and so we don't need to be inside a runtime.
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    map.lock().await.remove(&key);
+                });
+            }
+        }
+    }
+}
+
+/// Guard for the per-project-root concurrency map
+/// (`DaemonContext::concurrency`).
+pub type ConcurrencyGuard = MapKeyGuard<PathBuf, Uuid>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn guard_removes_on_drop() {
+        let map: Arc<Mutex<HashMap<PathBuf, Uuid>>> = Arc::new(Mutex::new(HashMap::new()));
+        let key = PathBuf::from("/repo");
+        let run_id = Uuid::new_v4();
+        {
+            let g = ConcurrencyGuard::acquire(map.clone(), key.clone(), run_id).await;
+            assert!(g.is_some());
+            assert!(map.lock().await.contains_key(&key));
+        }
+        // Drop spawns a task; wait until the removal task completes.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert!(
+            !map.lock().await.contains_key(&key),
+            "guard did not clean up on drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_returns_none_if_key_exists() {
+        let map: Arc<Mutex<HashMap<PathBuf, Uuid>>> = Arc::new(Mutex::new(HashMap::new()));
+        let key = PathBuf::from("/repo");
+        let _first = ConcurrencyGuard::acquire(map.clone(), key.clone(), Uuid::new_v4())
+            .await
+            .unwrap();
+        let second = ConcurrencyGuard::acquire(map.clone(), key, Uuid::new_v4()).await;
+        assert!(
+            second.is_none(),
+            "second acquire should fail while first is alive"
+        );
+    }
+
+    #[tokio::test]
+    async fn forget_keeps_entry() {
+        let map: Arc<Mutex<HashMap<PathBuf, Uuid>>> = Arc::new(Mutex::new(HashMap::new()));
+        let key = PathBuf::from("/repo");
+        let run_id = Uuid::new_v4();
+        {
+            let g = ConcurrencyGuard::acquire(map.clone(), key.clone(), run_id)
+                .await
+                .unwrap();
+            g.forget();
+        }
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert!(
+            map.lock().await.contains_key(&key),
+            "forget() should leave the entry in place for external cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn early_return_scenario_cleans_up() {
+        // Simulates `do_start_run` failing after acquiring the guard.
+        let map: Arc<Mutex<HashMap<PathBuf, Uuid>>> = Arc::new(Mutex::new(HashMap::new()));
+        let key = PathBuf::from("/repo");
+
+        async fn simulate(
+            map: Arc<Mutex<HashMap<PathBuf, Uuid>>>,
+            key: PathBuf,
+            fail: bool,
+        ) -> std::result::Result<(), &'static str> {
+            let _g = ConcurrencyGuard::acquire(map, key, Uuid::new_v4())
+                .await
+                .ok_or("busy")?;
+            if fail {
+                return Err("preflight failed");
+            }
+            Ok(())
+        }
+
+        assert!(simulate(map.clone(), key.clone(), true).await.is_err());
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert!(
+            !map.lock().await.contains_key(&key),
+            "map should be empty after early-return"
+        );
+    }
+}

--- a/crates/terminal-daemon/src/lib.rs
+++ b/crates/terminal-daemon/src/lib.rs
@@ -3,6 +3,7 @@ pub mod daemon_context;
 pub mod dispatcher;
 pub mod dispatchers;
 pub mod git_engine;
+pub mod guards;
 pub mod parser;
 pub mod persistence;
 pub mod pty;
@@ -69,10 +70,22 @@ pub async fn start_server(
     // Command channel (from WS clients to dispatcher)
     let (command_tx, mut command_rx) = mpsc::channel(64);
 
+    // Initialize persistence
+    let persistence = Arc::new(Persistence::new(config.data_dir.clone())?);
+
+    // Command dispatcher — constructed early so the WS handler can share its
+    // `active_workspaces` map (M5b, issue #100).
+    let dispatcher = Arc::new(Dispatcher::new(
+        config.clone(),
+        event_tx.clone(),
+        persistence.clone(),
+    ));
+
     let state = Arc::new(DaemonState {
         auth_token: token.clone(),
         event_tx: event_tx.clone(),
         command_tx,
+        active_workspaces: dispatcher.context().active_workspaces.clone(),
     });
 
     let app = build_router(state);
@@ -89,10 +102,7 @@ pub async fn start_server(
         tokio::fs::write(&port_path, actual_port.to_string()).await?;
     }
 
-    // Initialize persistence
-    let persistence = Arc::new(Persistence::new(config.data_dir.clone())?);
-
-    // Recovery on startup
+    // Recovery on startup — synchronous pass (metadata + run-state fixes).
     match persistence.recover() {
         Ok(report) => {
             if report.orphaned_runs > 0 || report.orphaned_worktrees > 0 {
@@ -107,15 +117,16 @@ pub async fn start_server(
         Err(e) => tracing::error!("Recovery failed: {}", e),
     }
 
-    // Command dispatcher
-    let dispatcher = Arc::new(Dispatcher::new(
-        config.clone(),
-        event_tx.clone(),
-        persistence.clone(),
-    ));
+    // Async pass: physically prune worktree directories whose metadata still
+    // exists but whose on-disk directory is gone (or the inverse). Keeps
+    // `git worktree list` clean across daemon restarts. See issue #86 (M17).
+    prune_orphan_worktrees_on_disk(&persistence).await;
+
+    // Startup recovery: re-hydrate persisted workspaces (C5b, issue #98).
+    dispatcher.recover_workspaces().await;
     tokio::spawn(async move {
-        while let Some((cmd, reply_tx)) = command_rx.recv().await {
-            dispatcher.handle(cmd, reply_tx).await;
+        while let Some((cmd, client_id, reply_tx)) = command_rx.recv().await {
+            dispatcher.handle(cmd, client_id, reply_tx).await;
         }
     });
 
@@ -138,4 +149,91 @@ pub async fn start_server(
         token,
         shutdown_tx: Some(shutdown_tx),
     })
+}
+
+/// Physically remove worktree directories whose metadata indicates they
+/// should be gone, and delete metadata whose worktree directory has been
+/// removed out-of-band. Best-effort: never fails startup.
+async fn prune_orphan_worktrees_on_disk(persistence: &Persistence) {
+    let metas = match persistence.list_worktree_metas() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!("prune_orphan_worktrees_on_disk: list failed: {}", e);
+            return;
+        }
+    };
+
+    for (run_id, meta) in metas {
+        let dir_exists = meta.worktree_path.exists();
+        // Look up whether the run is still alive in the on-disk run record.
+        let run_terminal = match persistence.load_run(run_id) {
+            Ok(run) => run.state.is_terminal(),
+            // No run record at all — metadata is orphaned, safe to delete.
+            Err(_) => true,
+        };
+
+        if !dir_exists {
+            // Worktree dir gone but metadata lingered; drop the metadata.
+            if let Err(e) = persistence.delete_worktree_meta(run_id) {
+                tracing::warn!(
+                    "prune_orphan_worktrees_on_disk: delete meta {} failed: {}",
+                    run_id,
+                    e
+                );
+            } else {
+                tracing::info!(
+                    "prune_orphan_worktrees_on_disk: removed stale metadata for missing worktree {:?}",
+                    meta.worktree_path
+                );
+            }
+            continue;
+        }
+
+        if run_terminal {
+            // Run is done but the worktree dir still exists — prune it.
+            let repo_root = meta
+                .repo_root
+                .clone()
+                .or_else(|| derive_repo_root_from_worktree(&meta.worktree_path));
+            if let Some(root) = repo_root {
+                if let Err(e) =
+                    crate::git_engine::worktree_remove(&root, &meta.worktree_path).await
+                {
+                    tracing::warn!(
+                        "prune_orphan_worktrees_on_disk: worktree_remove failed for {:?}: {}",
+                        meta.worktree_path,
+                        e
+                    );
+                } else {
+                    tracing::info!(
+                        "prune_orphan_worktrees_on_disk: pruned worktree {:?}",
+                        meta.worktree_path
+                    );
+                }
+            } else {
+                tracing::warn!(
+                    "prune_orphan_worktrees_on_disk: no repo_root for {:?}, skipping worktree_remove",
+                    meta.worktree_path
+                );
+            }
+            if let Err(e) = persistence.delete_worktree_meta(run_id) {
+                tracing::warn!(
+                    "prune_orphan_worktrees_on_disk: delete meta {} failed: {}",
+                    run_id,
+                    e
+                );
+            }
+        }
+    }
+}
+
+/// Derive the main repo root from a worktree path created under the
+/// convention `<repo_root>/.terminal-worktrees/<short_uuid>`. Returns None
+/// when the path doesn't match that layout.
+fn derive_repo_root_from_worktree(worktree_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let parent = worktree_path.parent()?;
+    if parent.file_name().and_then(|s| s.to_str()) != Some(".terminal-worktrees") {
+        return None;
+    }
+    parent.parent().map(|p| p.to_path_buf())
 }

--- a/crates/terminal-daemon/src/persistence.rs
+++ b/crates/terminal-daemon/src/persistence.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // Public API — consumers added in later tasks
-
 use std::fs;
 use std::path::{Path, PathBuf};
 use terminal_core::models::{
@@ -243,6 +241,11 @@ impl Persistence {
         Ok(())
     }
 
+    /// Path to the JSON metadata file for a given run's worktree.
+    pub fn worktree_meta_path(&self, run_id: Uuid) -> PathBuf {
+        self.base_dir.join("worktrees").join(format!("{}.json", run_id))
+    }
+
     pub fn list_worktree_metas(&self) -> Result<Vec<(Uuid, WorktreeMeta)>> {
         let dir = self.base_dir.join("worktrees");
         let mut metas = Vec::new();
@@ -354,11 +357,12 @@ impl Persistence {
 
             match self.load_run(run_id) {
                 Ok(run) if run.state.is_terminal() => {
-                    // TODO: call git_engine::worktree_remove for actual worktree cleanup
                     warn!(
                         "Recovery: removing orphaned worktree metadata for terminal run {}",
                         run_id
                     );
+                    // On-disk worktree cleanup happens separately in the async
+                    // reconcile pass (see `prune_orphan_worktrees_on_disk`).
                     fs::remove_file(&path)?;
                     report.orphaned_worktrees += 1;
                     report.cleaned_metadata += 1;
@@ -551,6 +555,7 @@ mod tests {
             base_head: "abc123".into(),
             merge_base: "abc123".into(),
             last_modified: Utc::now(),
+            repo_root: Some(PathBuf::from("/tmp/project")),
         }
     }
 

--- a/crates/terminal-daemon/src/pty/manager.rs
+++ b/crates/terminal-daemon/src/pty/manager.rs
@@ -27,8 +27,13 @@ pub struct PtySession {
 
 pub struct PtyManager {
     sessions: Arc<Mutex<HashMap<Uuid, PtySession>>>,
-    /// Global event broadcast (workspace-scoped routing happens in caller)
+    /// Global event broadcast — used as fallback when no workspace-scoped
+    /// channel is available.
     event_tx: broadcast::Sender<String>,
+    /// Shared workspace-scoped broadcast channels (M5c, issue #101). Kept as
+    /// an `Option` so tests that don't wire this can still run.
+    workspace_channels:
+        Option<Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>>,
 }
 
 impl PtyManager {
@@ -36,7 +41,56 @@ impl PtyManager {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
+            workspace_channels: None,
         }
+    }
+
+    /// Attach the shared workspace broadcast channel map. When set, terminal
+    /// events route to the owning workspace only, with fallback to the global
+    /// channel if the workspace has no subscribers.
+    pub fn with_workspace_channels(
+        mut self,
+        channels: Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>,
+    ) -> Self {
+        self.workspace_channels = Some(channels);
+        self
+    }
+
+    async fn emit(&self, workspace_id: Uuid, event: &AppEvent) {
+        Self::emit_via(
+            &self.event_tx,
+            self.workspace_channels.as_ref(),
+            workspace_id,
+            event,
+        )
+        .await;
+    }
+
+    async fn emit_via(
+        global: &broadcast::Sender<String>,
+        channels: Option<&Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>>,
+        workspace_id: Uuid,
+        event: &AppEvent,
+    ) {
+        if let Some(map) = channels {
+            let json = match serde_json::to_string(event) {
+                Ok(j) => j,
+                Err(e) => {
+                    warn!("PTY event serialization failed: {}", e);
+                    return;
+                }
+            };
+            let guard = map.lock().await;
+            if let Some(tx) = guard.get(&workspace_id) {
+                let _ = tx.send(json);
+                return;
+            }
+            drop(guard);
+            // Fallback to global channel so we don't drop events.
+            let _ = global.send(json);
+            return;
+        }
+        broadcast_event(global, event);
     }
 
     /// Create a new PTY session using a real pseudo-terminal via openpty(2).
@@ -189,16 +243,30 @@ impl PtyManager {
 
         // Spawn stdout reader task (reads from PTY master — single stream, PTY merges stdout+stderr).
         let event_tx_clone = self.event_tx.clone();
-        tokio::spawn(Self::stdout_reader(session_id, master_read, event_tx_clone));
+        let workspace_channels_reader = self.workspace_channels.clone();
+        tokio::spawn(Self::stdout_reader(
+            session_id,
+            workspace_id,
+            master_read,
+            event_tx_clone,
+            workspace_channels_reader,
+        ));
 
         // Spawn process watcher — removes session on child exit.
         let sessions_for_watcher = Arc::clone(&self.sessions);
         let event_tx_for_watcher = self.event_tx.clone();
+        let workspace_channels_watcher = self.workspace_channels.clone();
         tokio::spawn(async move {
             let mut child = child;
             let _ = child.wait().await;
             sessions_for_watcher.lock().await.remove(&session_id);
-            broadcast_event(&event_tx_for_watcher, &AppEvent::TerminalSessionClosed { session_id });
+            Self::emit_via(
+                &event_tx_for_watcher,
+                workspace_channels_watcher.as_ref(),
+                workspace_id,
+                &AppEvent::TerminalSessionClosed { session_id },
+            )
+            .await;
             info!("PTY session {} exited", session_id);
         });
 
@@ -221,7 +289,7 @@ impl PtyManager {
             is_ssh,
             ssh_host: ssh_host_label,
         };
-        broadcast_event(&self.event_tx, &created_event);
+        self.emit(workspace_id, &created_event).await;
 
         info!("PTY session {} created for workspace {}", session_id, workspace_id);
         Ok(session_id)
@@ -244,8 +312,11 @@ impl PtyManager {
 
     async fn stdout_reader(
         session_id: Uuid,
+        workspace_id: Uuid,
         mut reader: impl AsyncReadExt + Unpin,
         event_tx: broadcast::Sender<String>,
+        workspace_channels:
+            Option<Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>>,
     ) {
         let mut buf = vec![0u8; 4096];
         loop {
@@ -255,7 +326,13 @@ impl PtyManager {
                     // Real PTY line discipline handles \n → \r\n; no manual replacement needed.
                     let data = String::from_utf8_lossy(&buf[..n]).to_string();
                     let event = AppEvent::TerminalOutput { session_id, data };
-                    broadcast_event(&event_tx, &event);
+                    Self::emit_via(
+                        &event_tx,
+                        workspace_channels.as_ref(),
+                        workspace_id,
+                        &event,
+                    )
+                    .await;
                 }
             }
         }
@@ -304,12 +381,15 @@ impl PtyManager {
     pub async fn close_session(&self, session_id: Uuid) -> Result<(), String> {
         let mut sessions = self.sessions.lock().await;
         if let Some(session) = sessions.remove(&session_id) {
+            let workspace_id = session.meta.workspace_id;
             // Signal the stdin_writer task to exit; it will drop its tokio::fs::File,
             // closing the write half of the master PTY and sending EOF to the shell.
             // The stdout_reader task will exit when it sees EOF/error.
             // We do NOT call nix::libc::close() here — the Tokio Files own the fds.
             let _ = session.close_tx.send(()).await;
-            broadcast_event(&self.event_tx, &AppEvent::TerminalSessionClosed { session_id });
+            drop(sessions);
+            self.emit(workspace_id, &AppEvent::TerminalSessionClosed { session_id })
+                .await;
             Ok(())
         } else {
             Err(format!("Session {} not found", session_id))

--- a/crates/terminal-daemon/src/server.rs
+++ b/crates/terminal-daemon/src/server.rs
@@ -8,15 +8,20 @@ use axum::{
     Router,
 };
 use futures_util::{SinkExt, StreamExt};
+use std::collections::HashMap;
 use std::sync::Arc;
 use terminal_core::protocol::v1::{AppCommand, AppEvent};
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 pub struct DaemonState {
     pub auth_token: String,
     pub event_tx: broadcast::Sender<String>,
-    pub command_tx: mpsc::Sender<(AppCommand, mpsc::Sender<AppEvent>)>,
+    pub command_tx: mpsc::Sender<(AppCommand, Uuid, mpsc::Sender<AppEvent>)>,
+    /// Shared with `DaemonContext` so the WS handler can scrub a client's
+    /// entry on disconnect (M5b, issue #100).
+    pub active_workspaces: Arc<Mutex<HashMap<Uuid, Uuid>>>,
 }
 
 pub fn build_router(state: Arc<DaemonState>) -> Router {
@@ -40,8 +45,9 @@ fn event_json(event: &AppEvent) -> String {
 }
 
 async fn handle_socket(socket: WebSocket, state: Arc<DaemonState>) {
+    let client_id = Uuid::new_v4();
     let (mut sender, mut receiver) = socket.split();
-    info!("New WebSocket connection, awaiting auth...");
+    info!("New WebSocket connection ({}), awaiting auth...", client_id);
 
     // Step 1: Auth handshake — first message must be Auth command
     let authed = match tokio::time::timeout(
@@ -168,7 +174,9 @@ async fn handle_socket(socket: WebSocket, state: Arc<DaemonState>) {
                     }
                     Ok(cmd) => {
                         let cmd = cmd.sanitize();
-                        if let Err(e) = state.command_tx.send((cmd, response_tx.clone())).await {
+                        if let Err(e) =
+                            state.command_tx.send((cmd, client_id, response_tx.clone())).await
+                        {
                             error!("Failed to forward command: {}", e);
                         }
                     }
@@ -200,7 +208,9 @@ async fn handle_socket(socket: WebSocket, state: Arc<DaemonState>) {
 
     send_task.abort();
     response_task.abort();
-    info!("Client connection closed");
+    // M5b: scrub this client's active-workspace entry on disconnect.
+    state.active_workspaces.lock().await.remove(&client_id);
+    info!("Client connection closed ({})", client_id);
 }
 
 #[cfg(test)]
@@ -216,12 +226,13 @@ mod tests {
         let (event_tx, _) = broadcast::channel::<String>(16);
         // command_tx that simply drops all messages
         let (command_tx, _command_rx) =
-            mpsc::channel::<(AppCommand, mpsc::Sender<AppEvent>)>(16);
+            mpsc::channel::<(AppCommand, Uuid, mpsc::Sender<AppEvent>)>(16);
 
         let state = Arc::new(DaemonState {
             auth_token: token.clone(),
             event_tx,
             command_tx,
+            active_workspaces: Arc::new(Mutex::new(HashMap::new())),
         });
 
         let router = build_router(state);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5173:5173"
-    environment:
-      - VITE_DAEMON_WS_URL=ws://daemon:3000/ws
+    # VITE_DAEMON_WS_URL was removed (#85): the frontend now resolves the WS
+    # URL at runtime via `resolveDaemonWsUrl()` — same-origin `/ws` by default,
+    # proxied in dev through Vite. Set `window.__TERMINAL_CONFIG__.wsUrl` if
+    # you need to point the built bundle at a different daemon.
     depends_on:
       - daemon
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,139 +1,144 @@
-# AI Dev Terminal — Arquitetura Técnica (Opção 2)
+# Architecture
 
-Este documento define uma arquitetura prática para um terminal unificado que combina:
-- Operações com Claude Code por comandos simples.
-- Fluxos Git intuitivos e seguros.
+Terminal Engine is a Tauri v2 desktop app that manages AI coding sessions with
+git-integrated worktree sandboxing, plus general-purpose terminal and git panes.
+This document summarises the shipping architecture; see
+[`bin-cc.md`](./bin-cc.md) for the optional `cc` CLI helper that is *separate*
+from the app.
 
-## 1. Objetivos de produto
+## Overview
 
-- Permitir execução de tarefas de engenharia via comandos curtos (`cc ...`).
-- Preservar segurança e previsibilidade em operações destrutivas.
-- Integrar com Git de forma assistida e auditável.
-- Evitar dependência de UI externa para operações comuns.
+```
+frontend (React 19 + Vite)  ◄── WS ──►  terminal-daemon (Rust + Axum)
+                                                │
+                                                ├─ DaemonContext (shared state)
+                                                ├─ Dispatcher + domain dispatchers
+                                                ├─ PtyManager (terminal sessions)
+                                                ├─ GitEngine (tokio::process)
+                                                └─ Persistence (atomic JSON)
 
-## 2. Abordagem recomendada
-
-Implementar uma **CLI robusta** (Node.js ou Python), com wrappers para ferramentas existentes.
-
-### Porque não apenas scripts shell?
-Scripts shell funcionam para MVP, mas escalam mal para:
-- Estado de sessão.
-- Logs estruturados.
-- Parsing robusto de flags.
-- Plugins/comandos compostos.
-
-### Stack sugerida
-
-- **CLI**: Node.js + TypeScript (ou Python + Typer).
-- **Config**: arquivo local (`.cc-terminal.yml`) + defaults globais.
-- **Execução**: subprocess com timeout e captura de stdout/stderr.
-- **Persistência leve**:
-  - `~/.cc-terminal/sessions/` (logs por execução)
-  - `~/.cc-terminal/profiles/` (perfis por projeto)
-- **Integrações**:
-  - Git local (`git`)
-  - GitHub CLI (`gh`) para PR
-  - Claude Code via comando/API local conforme disponibilidade
-
-## 3. Camadas do sistema
-
-### 3.1 Interface de comandos
-
-Exemplos:
-- `cc ask "pergunta"`
-- `cc plan "objetivo"`
-- `cc do "objetivo"`
-- `cc review`
-- `cc commit`
-- `cc pr`
-
-Responsabilidades:
-- Validar input do utilizador.
-- Carregar perfil/projeto.
-- Encaminhar para orquestrador.
-
-### 3.2 Orquestrador
-
-Responsável por converter intenção em plano executável:
-1. Coletar contexto do repositório.
-2. Invocar Claude para plano/execução/revisão.
-3. Executar verificações (lint/test/type-check).
-4. Preparar resumo de alterações e próximos passos.
-
-### 3.3 Adaptadores de tooling
-
-- `gitAdapter`: branch status, diff, commit, rebase, push.
-- `testAdapter`: detetar e correr comandos de teste.
-- `prAdapter`: criar PR via `gh`.
-- `aiAdapter`: enviar prompts e receber respostas em formato estruturado.
-
-## 4. Modos de autonomia
-
-Definir três modos claros para reduzir risco:
-
-- `suggest`: apenas recomenda comandos/mudanças.
-- `apply`: altera ficheiros localmente, sem commit automático.
-- `full`: altera + valida + propõe commit/PR.
-
-**Regra**: operações destrutivas (`reset --hard`, delete branch, force push) exigem confirmação explícita.
-
-## 5. Guardrails obrigatórios
-
-- Bloquear operações diretas em `main`/`master` por defeito.
-- Exigir árvore limpa para comandos críticos (`cc commit`, `cc sync`).
-- Executar checks mínimos antes de commit:
-  - lint
-  - testes rápidos
-  - type-check (quando aplicável)
-- Verificar secrets antes de commit (`gitleaks`/`trufflehog` opcional).
-
-## 6. Estrutura de configuração
-
-Exemplo de `.cc-terminal.yml`:
-
-```yaml
-project:
-  default_branch: main
-  protected_branches: [main, master]
-  test_command: npm test -- --runInBand
-  lint_command: npm run lint
-  typecheck_command: npm run typecheck
-ai:
-  mode: apply
-  max_files_per_run: 20
-  require_plan_before_apply: true
-git:
-  branch_prefixes: [feature, fix, chore, refactor]
-  commit_convention: conventional
-  require_issue_reference: false
+terminal-app (Tauri v2) embeds the daemon in-process → same WS protocol.
 ```
 
-## 7. Observabilidade e auditoria
+### Workspace crates
 
-Cada execução deve gerar artefacto com:
-- comando invocado
-- timestamp
-- prompt enviado ao Claude
-- comandos shell executados
-- código de saída
-- ficheiros alterados
+| Crate | Role |
+|-------|------|
+| `terminal-core` | Shared types, protocol (`AppCommand`/`AppEvent`), domain models (`Workspace`, `PaneLayout`, `WorkspaceMode`), `DaemonConfig`, `DaemonMode` |
+| `terminal-daemon` | Library (`lib.rs`) + standalone binary (`main.rs`). Axum WS server, dispatchers, PTY manager, git engine, persistence |
+| `terminal-app` | Tauri v2 native shell — embeds daemon via `terminal_daemon::start_server()` |
 
-Formato recomendado: JSONL por sessão para facilitar parsing.
+Frontend lives in `frontend/` (React 19 + TypeScript + Vite).
 
-## 8. Roadmap técnico
+## Daemon
 
-### Fase 1 (MVP)
-- CLI base + `cc ask`, `cc plan`, `cc do`.
-- Integração Git simples (`status`, `diff`, `commit` assistido).
+### Modes (`DaemonMode`)
 
-### Fase 2 (Confiabilidade)
-- Modos `suggest/apply/full`.
-- Guardrails de branch + checks automáticos.
+- **Standalone** — CLI / Docker. Writes `~/.terminal-daemon/port` and
+  `~/.terminal-daemon/auth_token` so a browser client can discover it.
+- **Embedded** — Tauri. The daemon runs as a `tokio::spawn` task inside the
+  app process; port + token live in memory only, no files on disk.
 
-### Fase 3 (Integração GitHub)
-- `cc pr` com template automático.
-- Classificação de risco e checklist de validação.
+Both modes speak the same WebSocket protocol.
 
-### Fase 4 (UX avançada)
-- TUI opcional no terminal.
-- Perfis por stack (Node, Python, Go).
+### Components
+
+| Module | Purpose |
+|--------|---------|
+| `server.rs` | Axum WS server; auth handshake (first message must be `Auth { token }` within 10 s) |
+| `dispatcher.rs` | Command router — dispatches to domain dispatchers |
+| `daemon_context.rs` | Shared state: sessions, active runs, workspaces, PTY channels, persistence handles |
+| `dispatchers/workspace_dispatcher.rs` | Workspace lifecycle (create/close/activate) |
+| `dispatchers/git_dispatcher.rs` | Extended git ops (push/pull/fetch, merge conflicts) |
+| `pty/manager.rs` | Real PTY via `openpty(2)`; resize via `ioctl(TIOCSWINSZ)` |
+| `git_engine.rs` | Pure CLI git wrapper (`tokio::process::Command`); no libgit2 |
+| `persistence.rs` | Atomic JSON writes (`.tmp` → `rename`); crash recovery on startup |
+| `claude_runner.rs` | Claude subprocess runner with streaming output |
+
+### Channels
+
+- **`mpsc`** — client → dispatcher commands (per-connection reply channel).
+- **`broadcast`** — dispatcher → clients events. Each workspace has its own
+  `broadcast::Sender<String>` for event isolation (M1-05); otherwise falls back
+  to the global channel.
+- **`oneshot`** — shutdown signalling.
+
+### Persistence
+
+`~/.terminal-daemon/` subdirectories (standalone mode only):
+
+```
+sessions/   runs/   worktrees/   terminals/
+```
+
+Atomic writes guarantee no corrupt files on crash. The daemon re-hydrates
+in-flight runs from disk on startup.
+
+## Protocol
+
+`terminal-core/src/protocol/v1.rs` defines two flat enums with
+`#[serde(tag = "type")]`:
+
+- `AppCommand` — client → daemon (auth, sessions, runs, workspaces, git, PTY).
+- `AppEvent` — daemon → client (state transitions, output, errors, listings).
+
+Every new variant needs a roundtrip serialization test in the same module.
+
+## Frontend
+
+### State layers (M1-02)
+
+| Store | Scope |
+|-------|-------|
+| `state/app-store.ts` | Global: connection, sessions, workspaces |
+| `state/workspace-store.ts` | Per-workspace: runs, output, sidebar, terminal sessions |
+
+Both are plain reducers; the historical `context/AppContext.tsx` is wired in
+production and mirrors a subset of the new stores until the migration lands.
+
+### Service layer (M1-03)
+
+- `core/commands/commandBus.ts` — decouples UI from raw WS payload construction.
+- `core/events/eventRouter.ts` — routes every `AppEvent` variant to the correct
+  store. TS `assertNever` in the default arm is the compile-time guarantee.
+- `core/services/*.ts` — domain services (session, run, git, workspace,
+  terminal) that call the command bus.
+- `core/daemon/resolveDaemonWsUrl.ts` — runtime WS URL resolution. Precedence:
+  Tauri-injected info > `window.__TERMINAL_CONFIG__` > same-origin `/ws`.
+
+### Panes (M2)
+
+`panes/registry.ts` maps `PaneKind` → React component. `PaneRenderer.tsx` walks
+the recursive `PaneLayout` tree. Shipping kinds: `AiRun`, `Terminal`,
+`GitStatus`, `GitHistory`, `FileExplorer`, `Browser`, `Diff`, `FileViewer`,
+`Search`, `Empty`.
+
+### Modes (M3)
+
+`modes/registry.ts` holds `ModeDefinition`s registered by
+`modes/definitions.ts` (AiSession / Terminal / Git / Browser).
+
+## Data flow example
+
+Starting a run:
+
+1. User clicks **Run** in `AiRunPane` → `runService.start(prompt, mode)` →
+   `commandBus.dispatch({ type: 'StartRun', … })`.
+2. `useWebSocket.ts` sends the JSON payload over the open socket.
+3. Daemon `Dispatcher` receives, routes to run handler, spawns the Claude
+   subprocess inside a git worktree, streams stdout/stderr via
+   `broadcast::Sender<String>`.
+4. Each event lands back as `AppEvent` (`RunStateChanged`, `RunOutput`,
+   `RunCompleted`, …).
+5. `eventRouter.ts` dispatches the matching store action; panes re-render.
+
+## Docker, Tauri, and `run.sh`
+
+- `./run.sh` — development: `docker compose up` under the hood. Daemon on
+  `:3000`, Vite dev server on `:5173`, WS proxied via `/ws`.
+- `./release.sh` — production: builds a signed Tauri installer (`.deb` /
+  `.AppImage` / `.dmg` / `.msi`).
+- `make run` / `make desktop` / `make test` — convenience targets that wrap
+  the scripts above.
+
+See [`next-steps.md`](./next-steps.md) for the short getting-started.

--- a/docs/bin-cc.md
+++ b/docs/bin-cc.md
@@ -1,0 +1,93 @@
+# `bin/cc` — optional git helper
+
+`bin/cc` is a small shell script (~150 lines) with opinionated wrappers around
+common branch / commit / PR flows. **It is separate from the Terminal Engine
+app** — the app does not invoke it, and you can use the app without it.
+
+If you're looking for the shipping product, see
+[`architecture.md`](./architecture.md). This page only documents the helper
+script.
+
+## Install
+
+No install step — it's a script in the repo:
+
+```bash
+./bin/cc --help
+```
+
+Optionally put it on your `PATH`:
+
+```bash
+ln -s "$(pwd)/bin/cc" ~/.local/bin/cc
+```
+
+## Commands
+
+```text
+cc doctor
+cc branch start <ticket-slug>
+cc review
+cc sync
+cc commit [type] [message...]
+cc pr
+```
+
+### `cc doctor`
+
+Prints the current branch, ahead/behind counts vs `origin/<default-branch>`,
+working-tree status, and whether `gh` is installed.
+
+### `cc branch start <slug>`
+
+1. Refuses to run if the tree isn't clean.
+2. `git fetch --all --prune`.
+3. Checks out the default branch and fast-forwards it.
+4. Creates `feature/<slug>`.
+
+### `cc review`
+
+Local pre-PR review: lists changed files, `git diff --stat`, and the last five
+commits. Pure informational — nothing is modified.
+
+### `cc sync`
+
+`git fetch origin` + `git rebase origin/<default-branch>`. Stops on conflict —
+resolve manually, then `git rebase --continue`.
+
+### `cc commit [type] [message…]`
+
+`git add -A` + `git commit -m "<type>: <message>"`. `<type>` must be one of
+`feat|fix|chore|refactor|docs|test|perf`. Defaults to `chore: update files`.
+
+### `cc pr`
+
+Requires the GitHub CLI (`gh`). Runs `gh pr create --fill` with a minimal
+template. Title defaults to `<branch>: update`.
+
+## Configuration
+
+One environment variable:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CC_DEFAULT_BRANCH` | `main` | Branch name used by `cc doctor` / `cc branch start` / `cc sync` |
+
+There is no config file. (Earlier design sketches mentioned
+`.cc-terminal.yml`; that file was never implemented and has been removed from
+the docs — configure with `CC_DEFAULT_BRANCH` instead.)
+
+## Guardrails
+
+- Every command rejects running outside a git worktree.
+- `cc branch start` and `cc sync` refuse on a dirty tree.
+- `cc commit` enforces a conventional-commit prefix.
+- Nothing force-pushes; no `reset --hard`.
+
+## Relation to the app
+
+The Terminal Engine daemon exposes equivalent git operations via the
+WebSocket protocol (`StageFile`, `CreateCommit`, `PushBranch`, …) —
+see [`git-flow.md`](./git-flow.md). If you're already in the app, you don't
+need `cc`. The helper exists for terminal-only workflows and for users who
+want a scripted pre-commit flow outside the GUI.

--- a/docs/git-flow.md
+++ b/docs/git-flow.md
@@ -1,146 +1,84 @@
-# Fluxo Git Completo e Intuitivo (Opção 3)
+# Git in Terminal Engine
 
-Fluxo recomendado para combinar produtividade com segurança.
+This document describes the git surface that the daemon exposes and how the
+frontend panes use it. For the optional `cc` shell helper (legacy of the old
+CLI design), see [`bin-cc.md`](./bin-cc.md).
 
-## 1. Convenções
+## Daemon operations
 
-- Branch principal protegida: `main`.
-- Prefixos:
-  - `feature/<ticket>-<slug>`
-  - `fix/<ticket>-<slug>`
-  - `chore/<ticket>-<slug>`
-  - `refactor/<ticket>-<slug>`
-- Commits em conventional commits:
-  - `feat: ...`
-  - `fix: ...`
-  - `chore: ...`
-  - `refactor: ...`
+All git operations go through `git_engine.rs` — pure CLI invocations via
+`tokio::process::Command`. No libgit2.
 
-## 2. Sequência operacional
+| AppCommand | What the daemon does |
+|------------|----------------------|
+| `GetRepoStatus` | `git status --porcelain=v1`, rev-parse HEAD / branch |
+| `GetChangedFiles { mode }` | Status for working tree, or diff for a completed run |
+| `GetFileDiff { file_path, mode, run_id? }` | `git diff` scoped to one file |
+| `StageFile` / `UnstageFile` | `git add <path>` / `git restore --staged <path>` |
+| `CreateCommit { message }` | `git commit -m` on staged changes |
+| `ListBranches` / `CheckoutBranch` / `CreateBranch` | Branch navigation |
+| `GetCommitHistory { limit }` | `git log --oneline` with author/date metadata |
+| `ListStashes` / `GetStashFiles` / `GetStashDiff` | Stash browser |
+| `CheckDirtyState` | Uncommitted-changes probe before starting a run |
+| `StashAndRun` | `git stash` + `StartRun`, then restore after |
+| `PushBranch` / `PullBranch` / `FetchRemote` | Remote ops (M5-03) |
+| `GetMergeConflicts` / `ResolveConflict` | 3-way conflict editor (M5-05) |
 
-### Passo A — Criar branch de trabalho
+Each operation replies with a matching `AppEvent` (`RepoStatusResult`,
+`ChangedFilesList`, `FileDiffResult`, `CommitCreated`, `BranchList`,
+`StashList`, `PushCompleted`, `PullCompleted`, `MergeConflicts`, etc.).
+Errors surface as `GitOperationFailed { operation, reason }`.
 
-Comando alvo:
+## Run isolation via worktrees
+
+When the user starts an AI run, the daemon:
+
+1. Checks `CheckDirtyState`. If dirty and the user didn't opt into
+   `StashAndRun`, it emits `DirtyWarning` and waits for confirmation.
+2. Creates a worktree in `.terminal-worktrees/<run-id>/` from the current
+   branch head.
+3. Runs Claude inside that worktree (so the user's checkout is untouched).
+4. On completion emits `RunCompleted` with a `DiffStat`. The frontend shows a
+   **Merge** / **Revert** choice in `PostRunSummary`.
+
+`MergeRun` squashes the run's diff back into the user's branch; `RevertRun`
+deletes the worktree. Both paths clean up the worktree meta in
+`~/.terminal-daemon/worktrees/`.
+
+## Frontend panes
+
+| Pane | Uses |
+|------|------|
+| `GitStatusPane` | `RepoStatusResult`, `ChangedFilesList`, stage/unstage, commit box |
+| `GitHistoryPane` | `CommitHistoryResult` |
+| `MergeConflictPane` | `MergeConflicts`, `ResolveConflict` with 3-way view |
+| `StashDrawer` | `StashList`, `StashFiles`, `StashDiff` |
+| `DirtyWarningModal` | `DirtyWarning` → `StashAndRun` / `StartRun { skip_dirty_check }` / cancel |
+| `CommandPalette` | `BranchList` for quick `CheckoutBranch` |
+
+Toasts for `PushCompleted`, `PullCompleted`, `FetchCompleted`,
+`GitOperationFailed` are dispatched from the event router into the workspace
+store's `gitToast` slot and shown in `StatusBar`.
+
+## Guardrails
+
+Guardrails are per-operation and enforced in the daemon:
+
+- Dirty-tree check before every run.
+- `ResolveConflict` refuses if the file no longer has conflict markers.
+- Worktree paths are derived from run UUIDs to avoid collisions.
+- `PushBranch` / `PullBranch` default to the current branch + `origin`; the
+  frontend never force-pushes.
+
+UI-level guardrails (protected-branch warning, commit-type enforcement,
+conventional-commit templates) live in the optional `cc` helper — see
+[`bin-cc.md`](./bin-cc.md).
+
+## Testing git flows
+
 ```bash
-cc branch start 1234-login-flow
+docker compose run --rm test cargo test -p terminal-daemon git_engine
 ```
 
-A CLI deve:
-1. Validar se a árvore está limpa.
-2. Atualizar refs remotas (`git fetch --all --prune`).
-3. Criar branch a partir de `main` atualizada.
-
-### Passo B — Implementar com assistência AI
-
-Comando alvo:
-```bash
-cc do "Implementar validação de sessão e testes"
-```
-
-A CLI deve:
-1. Gerar plano breve.
-2. Aplicar alterações em lotes pequenos.
-3. Mostrar diff resumido por ficheiro.
-
-### Passo C — Revisão local de alterações
-
-Comando alvo:
-```bash
-cc review
-```
-
-A CLI deve devolver:
-- Resumo técnico do diff.
-- Pontos de risco (breaking changes, segurança, migrações).
-- Sugestões de testes adicionais.
-
-### Passo D — Validar qualidade
-
-Comando alvo:
-```bash
-cc test
-```
-
-A CLI deve correr (na ordem):
-1. lint
-2. type-check
-3. testes
-
-Se falhar, a CLI recomenda correção assistida (`cc do "corrigir erros de teste"`).
-
-### Passo E — Commit assistido
-
-Comando alvo:
-```bash
-cc commit
-```
-
-A CLI deve:
-1. Verificar checks mínimos.
-2. Gerar mensagem de commit pelo diff.
-3. Mostrar preview e pedir confirmação.
-4. Executar commit.
-
-### Passo F — Sincronizar com remoto
-
-Comando alvo:
-```bash
-cc sync
-```
-
-A CLI deve:
-1. `git fetch`.
-2. `git rebase origin/main`.
-3. Assistir resolução de conflitos (resumo + próximos comandos).
-
-### Passo G — Abrir PR
-
-Comando alvo:
-```bash
-cc pr
-```
-
-A CLI deve gerar automaticamente:
-- título
-- resumo
-- motivação
-- como testar
-- riscos/rollback
-
-E executar `gh pr create` com o conteúdo.
-
-## 3. Guardrails de segurança
-
-- Bloquear commit/push para `main` por defeito.
-- Proibir `push --force` sem flag explícita `--allow-force`.
-- Abort automático se houver ficheiros com conflito não resolvido.
-- Aviso alto se mudar ficheiros sensíveis (`infra/`, `migrations/`, `auth/`).
-
-## 4. UX de comandos (respostas curtas e úteis)
-
-A CLI deve sempre responder com:
-1. O que fez.
-2. O estado atual (`branch`, `ahead/behind`, `working tree`).
-3. Próximo comando recomendado.
-
-Exemplo:
-```text
-✅ Branch criada: feature/1234-login-flow
-ℹ️ Estado: clean, 0 commits ahead
-➡️ Próximo passo: cc do "..."
-```
-
-## 5. Métricas de sucesso do fluxo
-
-- Tempo médio branch -> PR.
-- Percentagem de PRs aprovadas sem mudanças grandes.
-- Taxa de falhas em CI por PR.
-- Número de reversões pós-merge.
-
-## 6. Checklist de adoção em equipa
-
-- [ ] Definir convenção de branch.
-- [ ] Definir comandos de lint/type-check/test por projeto.
-- [ ] Ativar branch protection no remoto.
-- [ ] Adotar template de PR padrão.
-- [ ] Treinar equipa em `cc review`, `cc commit`, `cc pr`.
+The tests spin up ephemeral repos in `tempfile::TempDir` and run the real
+`git` binary inside the container.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -2,25 +2,49 @@
 
 ## Short answer
 
-- Want a **native desktop app**? Run `make desktop`
-- Want to develop locally? Run `make run` and open your browser
-- Need to run tests? Use `make test`
+- Want a **native desktop app**? Run `./release.sh` (or `make desktop`).
+- Want to develop locally? Run `./run.sh` (or `make run`) and open your browser.
+- Need to run tests? `docker compose run --rm --profile test test` (or `make test`).
 
-## Quick start
+## Commands
 
 ```bash
-make help       # See all available commands
-make run        # Start daemon + frontend
-make desktop    # Build native Tauri app
-make test       # Run all tests
+make help           # list available Makefile targets
+./run.sh            # start daemon + frontend via docker compose
+./run.sh stop       # stop the dev stack
+./release.sh        # build and package the Tauri desktop app
+make test           # Rust tests (docker) + frontend tests (host)
 ```
 
 ## Development workflow
 
-1. Run `make run` to start the dev environment
-2. Open http://localhost:5173 in your browser
-3. Enter a project path and start a session
-4. Type a prompt to run Claude in an isolated git worktree
-5. Review the changes and merge/revert as needed
+1. Run `./run.sh` to start the dev environment.
+2. Open <http://localhost:5173>.
+3. Create a workspace pointing at a project path.
+4. Start an AI session and type a prompt — the daemon creates a worktree and
+   runs Claude inside it.
+5. Review the diff in `PostRunSummary` and merge or revert.
 
-For more details, see the [main README](../README.md).
+See [`architecture.md`](./architecture.md) for the full picture.
+
+## Roadmap (current)
+
+| Milestone | Status |
+|-----------|--------|
+| M1 Foundation (state layers, service layer) | ✅ |
+| M2 Panes (registry, split layouts, drag-resize) | ✅ |
+| M3 Modes (AiSession / Terminal / Git / Browser) | ✅ |
+| M4 Terminal (PTY sessions, resize, restore) | ✅ |
+| M5 Git (stashes, push/pull, conflicts) | ✅ |
+| M6 Browser pane | ✅ |
+| M7 Polish (toasts, keybindings, shortcuts) | ✅ |
+| M11 Build tooling (`run.sh` / `release.sh` / Makefile) | ✅ |
+| M12 Docs refresh | ✅ (this PR) |
+| M14 Frontend tests | ✅ |
+| M16 Runtime WS URL | ✅ |
+
+## Related docs
+
+- [`architecture.md`](./architecture.md) — crates, daemon, protocol, frontend.
+- [`git-flow.md`](./git-flow.md) — git ops surface + panes that consume them.
+- [`bin-cc.md`](./bin-cc.md) — optional shell helper for common git workflows.

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -1,0 +1,77 @@
+# Frontend testing (M14)
+
+## Commands
+
+| Script | Purpose |
+|--------|---------|
+| `npm run test` | Single CI run (vitest run) |
+| `npm run test:watch` | Re-runs on file save |
+| `npm run test:coverage` | v8 coverage report (requires `@vitest/coverage-v8`) |
+
+## Config
+
+- Runner: **vitest 4**
+- DOM: **jsdom** (`vitest.config.ts`)
+- Globals: enabled (no need to import `describe`/`it`/`expect`)
+- Test file glob: `src/**/*.test.{ts,tsx}`
+
+Tests live next to the code they cover (e.g. `workspace-store.ts` +
+`workspace-store.test.ts`).
+
+## What's covered
+
+Priority targets from #83:
+
+| Module | Test file | Shape |
+|--------|-----------|-------|
+| `core/events/eventRouter.ts` | `eventRouter.test.ts` | Exhaustive `Record<AppEvent['type'], AppEvent>` samples — one per variant |
+| `state/app-store.ts` | `app-store.test.ts` | One test per `AppStoreAction` variant + completeness gate |
+| `state/workspace-store.ts` | `workspace-store.test.ts` | One test per `WorkspaceAction` variant + completeness gate |
+| `core/commands/commandBus.ts` | `commandBus.test.ts` | Forwarding contract + singleton init |
+| `core/daemon/resolveDaemonWsUrl.ts` | `resolveDaemonWsUrl.test.ts` | Precedence: Tauri > runtime config > same-origin |
+| `panes/empty/EmptyPane.tsx` | `EmptyPane.test.tsx` | Render smoke test |
+
+## Conventions
+
+### Reducer tests
+
+For reducers, the pattern is:
+
+1. Track action tags via a `covered` set — `run()` wrapper adds each dispatched
+   tag.
+2. Final completeness test asserts every variant has been exercised, using
+   `satisfies readonly WorkspaceAction['type'][]` so a renamed/removed tag
+   breaks compilation.
+
+This means adding a new action without a test fails the "covers every variant"
+check.
+
+### Event router
+
+`eventRouter.test.ts` uses `Record<AppEvent['type'], AppEvent>` for the sample
+table — TypeScript forbids missing keys at compile time. At runtime, the
+`assertNever` default arm in `eventRouter.ts` turns any unhandled protocol
+variant into a thrown error.
+
+### Pane smoke tests
+
+Pane components that depend on `AppContext` need the provider wrapped in a
+helper (not yet written — see `EmptyPane.test.tsx` for the context-free case).
+Every pane's smoke test should at minimum render without throwing.
+
+### Mocking
+
+- WebSocket / send fn → `vi.fn()` (see `commandBus.test.ts`).
+- `window.__TERMINAL_CONFIG__` / `__TERMINAL_DAEMON_INFO__` → set in
+  `beforeEach`, restored in `afterEach` (see `resolveDaemonWsUrl.test.ts`).
+- `@testing-library/react` `cleanup()` called in `afterEach` for pane tests.
+
+## When to add a test
+
+- **New `AppStoreAction` / `WorkspaceAction` variant** → add a case in the
+  matching `*-store.test.ts` AND extend the completeness array.
+- **New `AppEvent` variant** → TS will force you to extend `eventRouter.ts`;
+  also add an entry to `SAMPLES` in `eventRouter.test.ts`.
+- **New `AppCommand`** → either add it to the `samples` list in
+  `commandBus.test.ts` or rely on the existing forwarding contract.
+- **New pane** → add a render smoke test alongside the component.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { WelcomeScreen } from './components/WelcomeScreen';
 import { ToastContainer } from './components/ToastContainer';
 import { SshConnectDialog } from './components/SshConnectDialog';
 import type { SshConnectConfig } from './components/SshConnectDialog';
+import { resolveDaemonWsUrl } from './core/daemon/resolveDaemonWsUrl';
 
 // Side-effect imports: register panes and modes
 import './panes/terminal/TerminalPane';
@@ -318,7 +319,7 @@ function AppContent() {
       // Check for Tauri runtime (injected by the native shell, not present in browsers)
       if (!(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__) {
         debug('[Browser] Tauri runtime not detected, using standalone mode');
-        setDaemonUrl('ws://127.0.0.1:3000/ws');
+        setDaemonUrl(resolveDaemonWsUrl());
         setTauriMode(false);
         return;
       }
@@ -345,7 +346,7 @@ function AppContent() {
         setTauriMode(true);
       } catch {
         debug('[Browser] Tauri API import failed, using standalone mode');
-        setDaemonUrl('ws://127.0.0.1:3000/ws');
+        setDaemonUrl(resolveDaemonWsUrl());
         setTauriMode(false);
       }
     };
@@ -356,29 +357,10 @@ function AppContent() {
 
   const handleEvent = useCallback(
     (event: AppEvent) => {
+      // C3: every variant now flows through the reducer (or the terminalBus
+      // side effect wrapped into dispatch in AppProvider). No more
+      // `window.dispatchEvent(new CustomEvent(...))` for protocol events.
       dispatch({ type: 'HANDLE_EVENT', event });
-
-      // Route terminal events via CustomEvent (high-frequency, shouldn't go through React state)
-      if (event.type === 'TerminalSessionCreated' ||
-          event.type === 'TerminalOutput' ||
-          event.type === 'TerminalSessionClosed') {
-        window.dispatchEvent(new CustomEvent('terminal-event', { detail: event }));
-      }
-
-      // Route BranchList events via CustomEvent so CommandPalette can receive them
-      if (event.type === 'BranchList') {
-        window.dispatchEvent(new CustomEvent('branch-list', { detail: event }));
-      }
-
-      // Route file-viewer events so FileViewerPane can receive them without going through React state
-      if (event.type === 'FileContent' || event.type === 'FileReadError') {
-        window.dispatchEvent(new CustomEvent('file-viewer-event', { detail: event }));
-      }
-
-      // Route search results to SearchPane
-      if (event.type === 'SearchResults') {
-        window.dispatchEvent(new CustomEvent('search-results', { detail: event }));
-      }
     },
     [dispatch],
   );

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSend } from '../context/SendContext';
-import { useAppDispatch } from '../context/AppContext';
+import { useAppDispatch, useAppState } from '../context/AppContext';
 import type { PaneLayout } from '../domain/pane/types';
 import type { BranchInfo } from '../types/protocol';
 import { themes, applyTheme, getCurrentThemeId } from '../styles/themes';
@@ -52,7 +52,7 @@ export function CommandPalette({ open, onClose, onLayoutChange, onSplitH, onSpli
   const [saveName, setSaveName] = useState('');
   const [quickCmds, setQuickCmds] = useState<QuickCommand[]>([]);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
-  const [branches, setBranches] = useState<BranchInfo[]>([]);
+  const branches = useAppState().branches;
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Reload snippets whenever we enter quick-commands mode
@@ -301,7 +301,6 @@ export function CommandPalette({ open, onClose, onLayoutChange, onSplitH, onSpli
       setSelectedIndex(0);
       setMode('commands');
       setSaveName('');
-      setBranches([]);
       setTimeout(() => inputRef.current?.focus(), 0);
     }
   }, [open]);
@@ -320,15 +319,8 @@ export function CommandPalette({ open, onClose, onLayoutChange, onSplitH, onSpli
     }
   }, [effectiveMode, send]);
 
-  // Listen for BranchList events routed from App.tsx
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const event = (e as CustomEvent).detail;
-      setBranches(event.branches ?? []);
-    };
-    window.addEventListener('branch-list', handler);
-    return () => window.removeEventListener('branch-list', handler);
-  }, []);
+  // Branch list now arrives via the reducer (C3): `state.branches` is populated
+  // by the BranchList event handler in AppContext.
 
   const handleDeleteQuickCmd = (id: string, e: React.MouseEvent) => {
     e.stopPropagation();

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -77,6 +77,25 @@ export function StatusBar() {
 
       <span style={{ flex: 1 }} />
 
+      {state.gitToast && (
+        <StatusBarItem
+          onClick={() => dispatch({ type: 'DISMISS_GIT_TOAST' })}
+          title="Dismiss"
+        >
+          <span
+            style={{
+              color:
+                state.gitToast.kind === 'error' ? 'var(--accent-error)' : 'var(--accent-primary)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            {state.gitToast.kind === 'error' ? '⚠' : '✓'} {state.gitToast.message}
+          </span>
+        </StatusBarItem>
+      )}
+
       {isRunning && (
         <StatusBarItem
           onClick={() => window.dispatchEvent(new CustomEvent('focus-pane-kind', { detail: 'AiRun' }))}

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useEffect, useReducer, type Dispatch, type ReactNode } from 'react';
-import type { AppEvent, CommitEntry, DiffStat, DirtyStatus, FileChange, FileTreeEntry, MergeConflictFile, PreflightError, RepoStatus, RunMetrics, RunMode, RunState, RunSummary, SessionSummary, StashEntry, ToolCall } from '../types/protocol';
+import { createContext, useContext, useEffect, useReducer, useRef, type Dispatch, type ReactNode } from 'react';
+import type { AppEvent, BranchInfo, CommitEntry, DiffStat, DirtyStatus, FileChange, FileTreeEntry, MergeConflictFile, PreflightError, RepoStatus, RunMetrics, RunMode, RunState, RunSummary, SearchMatch, SessionSummary, StashEntry, ToolCall } from '../types/protocol';
+import { publishTerminalEvent } from '../core/events/terminalBus';
 
 // --- State ---
 
@@ -44,6 +45,34 @@ export interface AppState {
   runMetrics: RunMetrics | null;
   /** Preflight error surfaced when the Claude binary is missing/unauthenticated. */
   preflightError: PreflightError | null;
+
+  // Direct-to-state slices added by C3 (replacing window.dispatchEvent workarounds)
+  /** Branch list last reported by the daemon. Consumed by CommandPalette. */
+  branches: BranchInfo[];
+  /** Currently-viewed file + optional read error. Consumed by FileViewerPane. */
+  fileViewer:
+    | {
+        path: string;
+        content: string;
+        language: string;
+        truncated: boolean;
+        size_bytes: number;
+      }
+    | { path: string; error: string }
+    | null;
+  /** Most recent search result. Consumed by SearchPane. */
+  searchResult: {
+    query: string;
+    matches: SearchMatch[];
+    total_matches: number;
+    files_searched: number;
+    truncated: boolean;
+    duration_ms: number;
+  } | null;
+  /** Transient git-operation toast (push/pull/fetch/error). Auto-dismissed by the StatusBar. */
+  gitToast: { kind: 'push' | 'pull' | 'fetch' | 'error'; message: string; timestamp: number } | null;
+  /** Last-known dirty state snapshot for the active project. */
+  dirtyState: DirtyStatus | null;
 }
 
 const initialState: AppState = {
@@ -82,6 +111,11 @@ const initialState: AppState = {
   runToolCalls: new Map(),
   runMetrics: null,
   preflightError: null,
+  branches: [],
+  fileViewer: null,
+  searchResult: null,
+  gitToast: null,
+  dirtyState: null,
 };
 
 // --- Actions ---
@@ -100,9 +134,19 @@ type Action =
   | { type: 'SET_CHANGES_CONTEXT'; context: AppState['changesContext'] }
   | { type: 'OPEN_DIFF'; file: string }
   | { type: 'CLOSE_DIFF' }
-  | { type: 'SET_DIFF_MODE'; mode: AppState['diffPanel']['mode'] };
+  | { type: 'SET_DIFF_MODE'; mode: AppState['diffPanel']['mode'] }
+  | { type: 'DISMISS_GIT_TOAST' };
 
 const MAX_OUTPUT_LINES = 2000;
+
+/** Compile-time exhaustiveness guard for AppEvent variants.
+ *  Adding a new variant without a matching `case` in HANDLE_EVENT breaks TS
+ *  compilation at the call site. At runtime we log and let the caller fall
+ *  back to the unchanged state. */
+function assertExhaustive(event: never): void {
+  const e = event as { type?: string };
+  console.warn('[AppContext] unhandled AppEvent variant', e.type);
+}
 
 function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
@@ -144,6 +188,9 @@ function reducer(state: AppState, action: Action): AppState {
 
     case 'SET_DIFF_MODE':
       return { ...state, diffPanel: { ...state.diffPanel, mode: action.mode } };
+
+    case 'DISMISS_GIT_TOAST':
+      return { ...state, gitToast: null };
 
     case 'HANDLE_EVENT': {
       const event = action.event;
@@ -311,9 +358,6 @@ function reducer(state: AppState, action: Action): AppState {
           return { ...state, stashDiffs };
         }
 
-        case 'DirtyState':
-          return state;
-
         case 'DirtyWarning':
           return {
             ...state,
@@ -412,7 +456,141 @@ function reducer(state: AppState, action: Action): AppState {
           };
         }
 
+        // --- Run history pagination (C3) ---
+        case 'RunOutputPage': {
+          // Treat as append-only history for the active run. Callers that
+          // want fresh pages dispatch CLEAR_OUTPUT first.
+          if (event.run_id !== state.activeRun) return state;
+          const lines = [...state.outputLines, ...event.lines];
+          const trimmed =
+            lines.length > MAX_OUTPUT_LINES ? lines.slice(lines.length - MAX_OUTPUT_LINES) : lines;
+          return { ...state, outputLines: trimmed };
+        }
+
+        // --- Branch list (C3) — replaces window CustomEvent workaround ---
+        case 'BranchList':
+          return { ...state, branches: event.branches };
+
+        // --- File viewer (C3) — replaces window CustomEvent workaround ---
+        case 'FileContent':
+          return {
+            ...state,
+            fileViewer: {
+              path: event.path,
+              content: event.content,
+              language: event.language,
+              truncated: event.truncated,
+              size_bytes: event.size_bytes,
+            },
+          };
+
+        case 'FileReadError':
+          return {
+            ...state,
+            fileViewer: { path: event.path, error: event.error },
+          };
+
+        // --- Search (C3) — replaces window CustomEvent workaround ---
+        case 'SearchResults':
+          return {
+            ...state,
+            searchResult: {
+              query: event.query,
+              matches: event.matches,
+              total_matches: event.total_matches,
+              files_searched: event.files_searched,
+              truncated: event.truncated,
+              duration_ms: event.duration_ms,
+            },
+          };
+
+        // --- Git extended (C3) ---
+        case 'PushCompleted':
+          return {
+            ...state,
+            gitToast: {
+              kind: 'push',
+              message: `Pushed ${event.branch} → ${event.remote}`,
+              timestamp: Date.now(),
+            },
+          };
+
+        case 'PullCompleted':
+          return {
+            ...state,
+            gitToast: {
+              kind: 'pull',
+              message:
+                event.commits_applied === 0
+                  ? `${event.branch} is up to date`
+                  : `Pulled ${event.commits_applied} commit(s) into ${event.branch}`,
+              timestamp: Date.now(),
+            },
+          };
+
+        case 'FetchCompleted':
+          return {
+            ...state,
+            gitToast: {
+              kind: 'fetch',
+              message: `Fetched from ${event.remote}`,
+              timestamp: Date.now(),
+            },
+          };
+
+        case 'GitOperationFailed':
+          return {
+            ...state,
+            gitToast: {
+              kind: 'error',
+              message: `${event.operation} failed: ${event.reason}`,
+              timestamp: Date.now(),
+            },
+          };
+
+        // --- Dirty state snapshot (C3) ---
+        case 'DirtyState':
+          return { ...state, dirtyState: event.status };
+
+        // --- Terminal (C3) — the bounded xterm stream still flows via
+        // terminalBus; we also fire the publish as a side effect in the
+        // `HANDLE_EVENT` wrapper below. These reducer arms are noops so the
+        // default case only triggers for truly unhandled variants.
+        case 'TerminalSessionCreated':
+        case 'TerminalOutput':
+        case 'TerminalSessionClosed':
+          return state;
+
+        case 'TerminalSessionList':
+          // intentionally ignored: listing is consumed directly by panes via dedicated query
+          return state;
+
+        case 'TerminalSessionRestored':
+          // intentionally ignored: restoration re-uses the Created pathway on the pane side
+          return state;
+
+        case 'TerminalSessionRestoreFailed':
+          return {
+            ...state,
+            error: `Terminal restore failed: ${event.reason}`,
+          };
+
+        case 'RestorableTerminalSessions':
+          // intentionally ignored: only surfaced on demand via a pane query
+          return state;
+
+        // --- Workspace lifecycle (routed by App.tsx to workspace state store;
+        //     the legacy reducer doesn't mirror workspace state — it only
+        //     knows about the AI session workspace. Intentionally ignored
+        //     here so they flow through the dedicated WorkspaceSwitcher). ---
+        case 'WorkspaceList':
+        case 'WorkspaceCreated':
+        case 'WorkspaceClosed':
+        case 'WorkspaceActivated':
+          return state;
+
         default:
+          assertExhaustive(event);
           return state;
       }
     }
@@ -430,14 +608,48 @@ const AppDispatchContext = createContext<Dispatch<Action>>(() => {});
 export function AppProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
 
+  // Keep a ref pointed at the latest state so side-effect closures can read
+  // the freshest gitToast timestamp without re-running on every render.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
   // Fix 3: Persist diffPanel.mode to localStorage via useEffect (not in reducer)
   useEffect(() => {
     localStorage.setItem('diff-mode', state.diffPanel.mode);
   }, [state.diffPanel.mode]);
 
+  // Auto-dismiss git toast after 4s so users always see completion feedback
+  // without leaving stale state in the UI.
+  useEffect(() => {
+    if (!state.gitToast) return;
+    const ts = state.gitToast.timestamp;
+    const timer = setTimeout(() => {
+      if (stateRef.current.gitToast?.timestamp === ts) {
+        dispatch({ type: 'DISMISS_GIT_TOAST' });
+      }
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [state.gitToast]);
+
+  // Wrap dispatch so high-frequency terminal events are also broadcast on the
+  // in-memory terminalBus (consumed directly by TerminalPane's xterm writer).
+  const wrappedDispatch: Dispatch<Action> = (action) => {
+    if (action.type === 'HANDLE_EVENT') {
+      const e = action.event;
+      if (
+        e.type === 'TerminalSessionCreated' ||
+        e.type === 'TerminalOutput' ||
+        e.type === 'TerminalSessionClosed'
+      ) {
+        publishTerminalEvent(e);
+      }
+    }
+    dispatch(action);
+  };
+
   return (
     <AppStateContext.Provider value={state}>
-      <AppDispatchContext.Provider value={dispatch}>
+      <AppDispatchContext.Provider value={wrappedDispatch}>
         {children}
       </AppDispatchContext.Provider>
     </AppStateContext.Provider>

--- a/frontend/src/core/commands/commandBus.test.ts
+++ b/frontend/src/core/commands/commandBus.test.ts
@@ -1,0 +1,72 @@
+// M14 — CommandBus is a thin passthrough to the WS send function, so the
+// contract to verify is: (1) payloads are forwarded verbatim; (2) the
+// singleton getters fail fast if not initialised.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CommandBus, initCommandBus, getCommandBus } from './commandBus';
+import type { AppCommand } from '../../types/protocol';
+
+describe('CommandBus', () => {
+  it('dispatch forwards AppCommand payloads to the send fn', () => {
+    const send = vi.fn();
+    const bus = new CommandBus(send);
+    const cmd: AppCommand = { type: 'Ping' };
+    bus.dispatch(cmd);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(cmd);
+  });
+
+  it('dispatch preserves payload shape for each command variant', () => {
+    const send = vi.fn();
+    const bus = new CommandBus(send);
+    const samples: AppCommand[] = [
+      { type: 'Auth', token: 'tok' },
+      { type: 'StartSession', project_root: '/root' },
+      { type: 'StartRun', session_id: 's1', prompt: 'p', mode: 'Free' },
+      { type: 'CancelRun', run_id: 'r1', reason: 'user' },
+      { type: 'RespondToBlocking', run_id: 'r1', response: 'yes' },
+      { type: 'GetDiff', run_id: 'r1' },
+      { type: 'ListWorkspaces' },
+      { type: 'CreateWorkspace', name: 'w', root_path: '/', mode: 'Terminal' },
+      { type: 'CreateTerminalSession', workspace_id: 'w1' },
+      { type: 'WriteTerminalInput', session_id: 't1', data: 'ls\n' },
+      { type: 'ResizeTerminal', session_id: 't1', cols: 80, rows: 24 },
+      { type: 'PushBranch' },
+      { type: 'PullBranch', remote: 'origin', branch: 'main' },
+      { type: 'ReadFile', path: 'a' },
+      { type: 'SearchFiles', query: 'q' },
+    ];
+    for (const cmd of samples) bus.dispatch(cmd);
+    expect(send).toHaveBeenCalledTimes(samples.length);
+    samples.forEach((cmd, i) => {
+      expect(send.mock.calls[i]?.[0]).toBe(cmd);
+    });
+  });
+
+  describe('singleton', () => {
+    beforeEach(() => {
+      // Deliberately re-init: earlier tests may have left the module state
+      // populated. initCommandBus overwrites the singleton.
+      initCommandBus(vi.fn());
+    });
+
+    it('initCommandBus returns a bus bound to the given send fn', () => {
+      const send = vi.fn();
+      const bus = initCommandBus(send);
+      bus.dispatch({ type: 'Ping' });
+      expect(send).toHaveBeenCalledWith({ type: 'Ping' });
+    });
+
+    it('getCommandBus returns the same instance as initCommandBus', () => {
+      const bus = initCommandBus(vi.fn());
+      expect(getCommandBus()).toBe(bus);
+    });
+
+    it('getCommandBus dispatches through the initialised send fn', () => {
+      const send = vi.fn();
+      initCommandBus(send);
+      getCommandBus().dispatch({ type: 'Ping' });
+      expect(send).toHaveBeenCalledWith({ type: 'Ping' });
+    });
+  });
+});

--- a/frontend/src/core/daemon/resolveDaemonWsUrl.test.ts
+++ b/frontend/src/core/daemon/resolveDaemonWsUrl.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { resolveDaemonWsUrl } from './resolveDaemonWsUrl';
+
+describe('resolveDaemonWsUrl', () => {
+  const origConfig = window.__TERMINAL_CONFIG__;
+  const origDaemon = window.__TERMINAL_DAEMON_INFO__;
+
+  beforeEach(() => {
+    delete window.__TERMINAL_CONFIG__;
+    delete window.__TERMINAL_DAEMON_INFO__;
+  });
+
+  afterEach(() => {
+    window.__TERMINAL_CONFIG__ = origConfig;
+    window.__TERMINAL_DAEMON_INFO__ = origDaemon;
+  });
+
+  it('defaults to same-origin /ws', () => {
+    const url = resolveDaemonWsUrl();
+    expect(url).toMatch(/^ws:\/\/.+\/ws$/);
+  });
+
+  it('honours runtime override', () => {
+    window.__TERMINAL_CONFIG__ = { wsUrl: 'ws://override.example/ws' };
+    expect(resolveDaemonWsUrl()).toBe('ws://override.example/ws');
+  });
+
+  it('honours Tauri-provided port', () => {
+    window.__TERMINAL_DAEMON_INFO__ = { port: 9999 };
+    expect(resolveDaemonWsUrl()).toBe('ws://127.0.0.1:9999/ws');
+  });
+
+  it('prefers Tauri info over runtime config', () => {
+    window.__TERMINAL_CONFIG__ = { wsUrl: 'ws://runtime/ws' };
+    window.__TERMINAL_DAEMON_INFO__ = { wsUrl: 'ws://tauri/ws' };
+    expect(resolveDaemonWsUrl()).toBe('ws://tauri/ws');
+  });
+});

--- a/frontend/src/core/daemon/resolveDaemonWsUrl.ts
+++ b/frontend/src/core/daemon/resolveDaemonWsUrl.ts
@@ -1,0 +1,46 @@
+// Resolve the daemon WebSocket URL at runtime (M16).
+//
+// Order of precedence:
+// 1. Tauri: use the port/token injected by the native shell (via
+//    `get_daemon_info` — callers typically override this resolver in that
+//    code path).
+// 2. Runtime config: `window.__TERMINAL_CONFIG__.wsUrl` — lets operators
+//    override without rebuilding the image (e.g. split deployments).
+// 3. Same-origin default: `ws(s)://<host>/ws`. This works under a reverse
+//    proxy (compose/nginx), under `vite dev` (thanks to its `/ws` proxy),
+//    and under the Tauri bundled static server.
+//
+// NOTE: we deliberately do NOT read `import.meta.env.VITE_*`. That would
+// inline the URL at build time and make the image non-portable (#85).
+
+export interface RuntimeDaemonInfo {
+  wsUrl?: string;
+  token?: string;
+}
+
+declare global {
+  interface Window {
+    __TERMINAL_CONFIG__?: RuntimeDaemonInfo;
+    __TERMINAL_DAEMON_INFO__?: RuntimeDaemonInfo & { port?: number };
+  }
+}
+
+export function resolveDaemonWsUrl(): string {
+  // Tauri injects either a full URL or a port.
+  const tauri = typeof window !== 'undefined' ? window.__TERMINAL_DAEMON_INFO__ : undefined;
+  if (tauri?.wsUrl) return tauri.wsUrl;
+  if (tauri?.port) return `ws://127.0.0.1:${tauri.port}/ws`;
+
+  // Runtime override (written by a deploy script into index.html).
+  const runtime = typeof window !== 'undefined' ? window.__TERMINAL_CONFIG__ : undefined;
+  if (runtime?.wsUrl) return runtime.wsUrl;
+
+  // Same-origin default.
+  if (typeof window !== 'undefined' && window.location) {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${window.location.host}/ws`;
+  }
+
+  // SSR / test fallback.
+  return 'ws://127.0.0.1:3000/ws';
+}

--- a/frontend/src/core/events/eventRouter.test.ts
+++ b/frontend/src/core/events/eventRouter.test.ts
@@ -1,0 +1,243 @@
+// C3 acceptance test — every AppEvent variant must flow through the router
+// without throwing, either dispatching an action or hitting a deliberate
+// `intentionally ignored` arm. Adding a new variant without a corresponding
+// case will fail TS compilation in eventRouter.ts (`assertNever`) — this
+// test is the runtime safety net.
+
+import { describe, it, expect, vi } from 'vitest';
+import { EventRouter } from './eventRouter';
+import type { AppEvent } from '../../types/protocol';
+
+function makeRouter() {
+  const appDispatch = vi.fn();
+  const workspaceDispatch = vi.fn();
+  const router = new EventRouter(appDispatch, workspaceDispatch, () => 'ws-1');
+  return { router, appDispatch, workspaceDispatch };
+}
+
+// One sample payload per AppEvent variant. Kept intentionally small.
+// When a new variant is added, TS will fail at `AppEvent` assignment if this
+// table is missed, OR the router's `assertNever` will break compilation.
+const SAMPLES: Record<AppEvent['type'], AppEvent> = {
+  AuthSuccess: { type: 'AuthSuccess' },
+  AuthFailed: { type: 'AuthFailed', reason: 'nope' },
+  RunStateChanged: { type: 'RunStateChanged', run_id: 'r1', new_state: { type: 'Running' } },
+  RunOutput: { type: 'RunOutput', run_id: 'r1', line: 'hi', line_number: 1 },
+  RunBlocking: { type: 'RunBlocking', run_id: 'r1', question: 'ok?', context: [] },
+  RunCompleted: {
+    type: 'RunCompleted',
+    run_id: 'r1',
+    summary: {
+      id: 'r1',
+      state: { type: 'Completed', exit_code: 0 },
+      prompt_preview: 'p',
+      modified_file_count: 0,
+      started_at: 'x',
+      ended_at: null,
+      diff_stat: null,
+    },
+    diff_stat: null,
+  },
+  RunDiff: {
+    type: 'RunDiff',
+    run_id: 'r1',
+    stat: { files_changed: 0, insertions: 0, deletions: 0, file_stats: [] },
+    diff: '',
+  },
+  RunReverted: { type: 'RunReverted', run_id: 'r1' },
+  RunMerged: { type: 'RunMerged', run_id: 'r1', merge_result: 'Merged' },
+  RunMergeConflict: { type: 'RunMergeConflict', run_id: 'r1', conflict_paths: [] },
+  RunFailed: { type: 'RunFailed', run_id: 'r1', error: 'boom', phase: 'Execution' },
+  RunCancelled: { type: 'RunCancelled', run_id: 'r1' },
+  RunToolUse: {
+    type: 'RunToolUse',
+    run_id: 'r1',
+    tool_id: 't1',
+    tool_name: 'bash',
+    tool_input_preview: 'ls',
+  },
+  RunToolResult: {
+    type: 'RunToolResult',
+    run_id: 'r1',
+    tool_id: 't1',
+    is_error: false,
+    preview: 'ok',
+  },
+  RunMetrics: {
+    type: 'RunMetrics',
+    run_id: 'r1',
+    num_turns: 1,
+    cost_usd: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+  },
+  RunPreflightFailed: { type: 'RunPreflightFailed', run_id: 'r1', reason: 'x', suggestion: 'y' },
+  SessionStarted: {
+    type: 'SessionStarted',
+    session: {
+      id: 's1',
+      project_root: '/',
+      active_run: null,
+      run_count: 0,
+      started_at: 'now',
+    },
+  },
+  SessionEnded: { type: 'SessionEnded', session_id: 's1' },
+  SessionList: { type: 'SessionList', sessions: [] },
+  RunList: { type: 'RunList', session_id: 's1', runs: [] },
+  RunOutputPage: {
+    type: 'RunOutputPage',
+    run_id: 'r1',
+    offset: 0,
+    lines: ['a'],
+    has_more: false,
+  },
+  StatusUpdate: { type: 'StatusUpdate', active_runs: 0, session_count: 0 },
+  Pong: { type: 'Pong' },
+  Error: { type: 'Error', code: 'E', message: 'm' },
+  StashList: { type: 'StashList', stashes: [] },
+  StashFiles: { type: 'StashFiles', stash_index: 0, files: [] },
+  StashDiff: { type: 'StashDiff', stash_index: 0, diff: '', stat: null },
+  DirtyState: { type: 'DirtyState', status: { staged: [], unstaged: [] } },
+  DirtyWarning: {
+    type: 'DirtyWarning',
+    status: { staged: [], unstaged: [] },
+    session_id: 's1',
+    prompt: 'p',
+    mode: 'Free',
+  },
+  DirectoryListing: { type: 'DirectoryListing', path: '/', entries: [] },
+  ChangedFilesList: { type: 'ChangedFilesList', mode: 'working', run_id: undefined, files: [] },
+  FileDiffResult: { type: 'FileDiffResult', file_path: 'f', diff: '', stat: null },
+  RepoStatusResult: {
+    type: 'RepoStatusResult',
+    status: { branch: 'main', head: 'abc', clean: true, staged_count: 0, unstaged_count: 0 },
+  },
+  CommitHistoryResult: { type: 'CommitHistoryResult', commits: [] },
+  CommitCreated: { type: 'CommitCreated', hash: 'abc' },
+  BranchChanged: { type: 'BranchChanged', name: 'main' },
+  BranchList: { type: 'BranchList', branches: [], current: 'main' },
+  WorkspaceList: { type: 'WorkspaceList', workspaces: [] },
+  WorkspaceCreated: {
+    type: 'WorkspaceCreated',
+    workspace: {
+      id: 'w1',
+      name: 'x',
+      root_path: '/',
+      mode: 'Terminal',
+      linked_session_id: null,
+      last_active_at: 'now',
+    },
+  },
+  WorkspaceClosed: { type: 'WorkspaceClosed', workspace_id: 'w1' },
+  WorkspaceActivated: { type: 'WorkspaceActivated', workspace_id: 'w1' },
+  TerminalSessionCreated: {
+    type: 'TerminalSessionCreated',
+    session_id: 't1',
+    workspace_id: 'w1',
+    shell: 'bash',
+    cwd: '/',
+  },
+  TerminalSessionClosed: { type: 'TerminalSessionClosed', session_id: 't1' },
+  TerminalOutput: { type: 'TerminalOutput', session_id: 't1', data: 'hi' },
+  TerminalSessionList: { type: 'TerminalSessionList', workspace_id: 'w1', sessions: [] },
+  TerminalSessionRestored: {
+    type: 'TerminalSessionRestored',
+    previous_session_id: 'p1',
+    new_session_id: 't2',
+    cwd: '/',
+    workspace_id: 'w1',
+  },
+  TerminalSessionRestoreFailed: {
+    type: 'TerminalSessionRestoreFailed',
+    previous_session_id: 'p1',
+    reason: 'x',
+  },
+  RestorableTerminalSessions: {
+    type: 'RestorableTerminalSessions',
+    workspace_id: 'w1',
+    sessions: [],
+  },
+  PushCompleted: { type: 'PushCompleted', branch: 'main', remote: 'origin' },
+  PullCompleted: { type: 'PullCompleted', branch: 'main', commits_applied: 0 },
+  FetchCompleted: { type: 'FetchCompleted', remote: 'origin' },
+  GitOperationFailed: { type: 'GitOperationFailed', operation: 'push', reason: 'x' },
+  MergeConflicts: { type: 'MergeConflicts', files: [] },
+  ConflictResolved: { type: 'ConflictResolved', file_path: 'f' },
+  FileContent: {
+    type: 'FileContent',
+    path: 'a',
+    content: '',
+    language: 'ts',
+    truncated: false,
+    size_bytes: 0,
+  },
+  FileReadError: { type: 'FileReadError', path: 'a', error: 'x' },
+  SearchResults: {
+    type: 'SearchResults',
+    query: 'q',
+    matches: [],
+    total_matches: 0,
+    files_searched: 0,
+    truncated: false,
+    duration_ms: 1,
+  },
+};
+
+describe('EventRouter — C3 completeness', () => {
+  it('dispatches every AppEvent variant without throwing', () => {
+    for (const [tag, sample] of Object.entries(SAMPLES)) {
+      const { router, appDispatch, workspaceDispatch } = makeRouter();
+      expect(() => router.route(sample), `variant ${tag}`).not.toThrow();
+      // At least ONE of the two dispatchers must have been invoked — the only
+      // exception is deliberately-ignored events. Track them explicitly.
+      const deliberatelyIgnored = new Set([
+        'StatusUpdate',
+        'RunReverted',
+        'CommitCreated',
+        'TerminalOutput',
+      ]);
+      if (!deliberatelyIgnored.has(tag)) {
+        expect(
+          appDispatch.mock.calls.length + workspaceDispatch.mock.calls.length,
+          `variant ${tag} should dispatch at least once`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('routes app-level events to the app dispatcher', () => {
+    const { router, appDispatch, workspaceDispatch } = makeRouter();
+    router.route({ type: 'Pong' });
+    expect(appDispatch).toHaveBeenCalledWith({ type: 'SET_LAST_PONG' });
+    expect(workspaceDispatch).not.toHaveBeenCalled();
+  });
+
+  it('routes workspace-scoped events to the workspace dispatcher', () => {
+    const { router, appDispatch, workspaceDispatch } = makeRouter();
+    router.route({
+      type: 'RunStateChanged',
+      run_id: 'r1',
+      new_state: { type: 'Running' },
+    });
+    expect(workspaceDispatch).toHaveBeenCalled();
+    expect(workspaceDispatch.mock.calls[0]?.[0]).toBe('ws-1');
+    expect(appDispatch).not.toHaveBeenCalled();
+  });
+
+  it('drops workspace-scoped events when no active workspace', () => {
+    const appDispatch = vi.fn();
+    const workspaceDispatch = vi.fn();
+    const router = new EventRouter(appDispatch, workspaceDispatch, () => null);
+    router.route({ type: 'RunOutput', run_id: 'r1', line: 'x', line_number: 1 });
+    expect(workspaceDispatch).not.toHaveBeenCalled();
+    expect(appDispatch).not.toHaveBeenCalled();
+  });
+
+  it('SAMPLES has an entry for every AppEvent variant', () => {
+    // Every `AppEvent['type']` literal is a key in SAMPLES — TS enforces this
+    // via `Record<AppEvent['type'], AppEvent>`. Guard at runtime too.
+    const tags = Object.keys(SAMPLES).sort();
+    expect(tags.length).toBeGreaterThan(40);
+  });
+});

--- a/frontend/src/core/events/eventRouter.ts
+++ b/frontend/src/core/events/eventRouter.ts
@@ -1,4 +1,10 @@
-// Event router — routes raw daemon events to the correct state layer (M1-03)
+// Event router — routes raw daemon events to the correct state layer (M1-03, C3).
+//
+// Every `AppEvent` variant is handled explicitly. When a variant genuinely
+// has no routing target (e.g. purely informational), the switch arm is
+// annotated with `// intentionally ignored: <reason>`. New protocol variants
+// must be handled here — the `default: never` arm at the bottom of
+// `routeToWorkspace` breaks compilation on any unhandled tag.
 
 import type { AppEvent } from '../../types/protocol';
 import type { AppStoreAction } from '../../state/app-store';
@@ -7,8 +13,11 @@ import type { WorkspaceAction } from '../../state/workspace-store';
 export type AppStoreDispatch = (action: AppStoreAction) => void;
 export type WorkspaceDispatch = (workspaceId: string, action: WorkspaceAction) => void;
 
-/** Global (app-level) event types. */
-const APP_LEVEL_EVENTS = new Set([
+/**
+ * Events that pertain to the whole app (auth, sessions, workspaces, status).
+ * Anything NOT listed here is routed to the active workspace.
+ */
+const APP_LEVEL_EVENTS = new Set<AppEvent['type']>([
   'AuthSuccess',
   'AuthFailed',
   'Pong',
@@ -68,6 +77,9 @@ export class EventRouter {
       case 'SessionList':
         this.appDispatch({ type: 'SET_SESSIONS', sessions: event.sessions });
         break;
+      case 'StatusUpdate':
+        // intentionally ignored: dashboard heartbeat, no store slice yet
+        break;
       case 'Error':
         this.appDispatch({ type: 'SET_ERROR', error: `${event.code}: ${event.message}` });
         break;
@@ -83,6 +95,9 @@ export class EventRouter {
       case 'WorkspaceActivated':
         this.appDispatch({ type: 'SET_ACTIVE_WORKSPACE', workspaceId: event.workspace_id });
         break;
+      default:
+        // Should be unreachable — events in APP_LEVEL_EVENTS must be handled above.
+        console.warn('[eventRouter] unhandled app-level event', event);
     }
   }
 
@@ -91,6 +106,24 @@ export class EventRouter {
       this.workspaceDispatch(workspaceId, action);
 
     switch (event.type) {
+      // Events already classified as app-level — routed here only if the caller
+      // bypassed `route()`. Forward to the app dispatcher.
+      case 'AuthSuccess':
+      case 'AuthFailed':
+      case 'Pong':
+      case 'SessionStarted':
+      case 'SessionEnded':
+      case 'SessionList':
+      case 'StatusUpdate':
+      case 'Error':
+      case 'WorkspaceList':
+      case 'WorkspaceCreated':
+      case 'WorkspaceClosed':
+      case 'WorkspaceActivated':
+        this.routeToApp(event);
+        break;
+
+      // --- Run lifecycle ---
       case 'RunStateChanged':
         dispatch({ type: 'SET_ACTIVE_RUN', runId: event.run_id });
         dispatch({ type: 'SET_RUN_STATE', runState: event.new_state });
@@ -98,6 +131,12 @@ export class EventRouter {
         break;
       case 'RunOutput':
         dispatch({ type: 'APPEND_OUTPUT', line: event.line });
+        break;
+      case 'RunOutputPage':
+        // Paginated history load: append each line in order.
+        for (const line of event.lines) {
+          dispatch({ type: 'APPEND_OUTPUT', line });
+        }
         break;
       case 'RunBlocking':
         dispatch({ type: 'SET_BLOCKING', question: event.question, context: event.context });
@@ -122,6 +161,7 @@ export class EventRouter {
         dispatch({ type: 'SET_DIFF', runId: event.run_id, stat: event.stat, diff: event.diff });
         break;
       case 'RunReverted':
+        // intentionally ignored: legacy event; UI reacts to the follow-up RunList refresh
         break;
       case 'RunMerged':
         dispatch({ type: 'CLEAR_MERGE_CONFLICT' });
@@ -129,6 +169,49 @@ export class EventRouter {
       case 'RunMergeConflict':
         dispatch({ type: 'SET_MERGE_CONFLICT', runId: event.run_id, paths: event.conflict_paths });
         break;
+
+      // --- Run structured telemetry (TERMINAL-055) ---
+      case 'RunToolUse':
+        dispatch({
+          type: 'ADD_TOOL_CALL',
+          runId: event.run_id,
+          toolCall: {
+            tool_id: event.tool_id,
+            tool_name: event.tool_name,
+            input_preview: event.tool_input_preview,
+            status: 'pending',
+          },
+        });
+        break;
+      case 'RunToolResult':
+        dispatch({
+          type: 'UPDATE_TOOL_RESULT',
+          runId: event.run_id,
+          toolId: event.tool_id,
+          isError: event.is_error,
+          resultPreview: event.preview,
+        });
+        break;
+      case 'RunMetrics':
+        dispatch({
+          type: 'SET_RUN_METRICS',
+          runId: event.run_id,
+          metrics: {
+            num_turns: event.num_turns,
+            cost_usd: event.cost_usd,
+            input_tokens: event.input_tokens,
+            output_tokens: event.output_tokens,
+          },
+        });
+        break;
+      case 'RunPreflightFailed':
+        dispatch({
+          type: 'SET_PREFLIGHT_ERROR',
+          error: { reason: event.reason, suggestion: event.suggestion },
+        });
+        break;
+
+      // --- Stash / dirty ---
       case 'StashList':
         dispatch({ type: 'SET_STASHES', stashes: event.stashes });
         break;
@@ -136,19 +219,44 @@ export class EventRouter {
         dispatch({ type: 'SET_STASH_FILES', stashIndex: event.stash_index, files: event.files });
         break;
       case 'StashDiff':
-        dispatch({ type: 'SET_STASH_DIFF', stashIndex: event.stash_index, diff: event.diff, stat: event.stat });
+        dispatch({
+          type: 'SET_STASH_DIFF',
+          stashIndex: event.stash_index,
+          diff: event.diff,
+          stat: event.stat,
+        });
+        break;
+      case 'DirtyState':
+        dispatch({ type: 'SET_DIRTY_STATE', status: event.status });
         break;
       case 'DirtyWarning':
-        dispatch({ type: 'SET_DIRTY_WARNING', status: event.status, session_id: event.session_id, prompt: event.prompt, mode: event.mode });
+        dispatch({
+          type: 'SET_DIRTY_WARNING',
+          status: event.status,
+          session_id: event.session_id,
+          prompt: event.prompt,
+          mode: event.mode,
+        });
         break;
+
+      // --- Sidebar / file tree ---
       case 'DirectoryListing':
         dispatch({ type: 'SET_DIRECTORY', path: event.path, entries: event.entries });
         break;
       case 'ChangedFilesList':
-        dispatch({ type: 'SET_CHANGED_FILES', context: { mode: event.mode as 'working' | 'run', runId: event.run_id }, files: event.files });
+        dispatch({
+          type: 'SET_CHANGED_FILES',
+          context: { mode: event.mode as 'working' | 'run', runId: event.run_id },
+          files: event.files,
+        });
         break;
       case 'FileDiffResult':
-        dispatch({ type: 'SET_DIFF_CONTENT', file: event.file_path, diff: event.diff, stat: event.stat });
+        dispatch({
+          type: 'SET_DIFF_CONTENT',
+          file: event.file_path,
+          diff: event.diff,
+          stat: event.stat,
+        });
         break;
       case 'RepoStatusResult':
         dispatch({ type: 'SET_REPO_STATUS', status: event.status });
@@ -156,8 +264,17 @@ export class EventRouter {
       case 'CommitHistoryResult':
         dispatch({ type: 'SET_COMMIT_HISTORY', commits: event.commits });
         break;
-      case 'BranchChanged':
+      case 'CommitCreated':
+        // intentionally ignored: follow-up RepoStatusResult/CommitHistoryResult refreshes the UI
         break;
+      case 'BranchChanged':
+        dispatch({ type: 'SET_BRANCH_NAME', name: event.name });
+        break;
+      case 'BranchList':
+        dispatch({ type: 'SET_BRANCH_LIST', branches: event.branches, current: event.current });
+        break;
+
+      // --- PTY / terminal ---
       case 'TerminalSessionCreated':
         dispatch({
           type: 'ADD_TERMINAL_SESSION',
@@ -177,12 +294,109 @@ export class EventRouter {
       case 'TerminalSessionList':
         dispatch({ type: 'SET_TERMINAL_SESSIONS', sessions: event.sessions });
         break;
+      case 'TerminalOutput':
+        // intentionally ignored: high-frequency; consumed via terminalBus by the pane.
+        break;
+      case 'TerminalSessionRestored':
+        dispatch({
+          type: 'ADD_TERMINAL_SESSION',
+          session: {
+            session_id: event.new_session_id,
+            workspace_id: event.workspace_id,
+            shell: '',
+            cwd: event.cwd,
+            created_at: new Date().toISOString(),
+            last_active_at: new Date().toISOString(),
+          },
+        });
+        break;
+      case 'TerminalSessionRestoreFailed':
+        // Surface as an app-level error so the user sees it.
+        this.appDispatch({
+          type: 'SET_ERROR',
+          error: `Could not restore terminal ${event.previous_session_id}: ${event.reason}`,
+        });
+        break;
+      case 'RestorableTerminalSessions':
+        dispatch({ type: 'SET_RESTORABLE_TERMINALS', sessions: event.sessions });
+        break;
+
+      // --- Git extended (M5-04) ---
+      case 'PushCompleted':
+        dispatch({
+          type: 'SET_GIT_TOAST',
+          toast: { kind: 'push', message: `Pushed ${event.branch} → ${event.remote}` },
+        });
+        break;
+      case 'PullCompleted':
+        dispatch({
+          type: 'SET_GIT_TOAST',
+          toast: {
+            kind: 'pull',
+            message:
+              event.commits_applied === 0
+                ? `${event.branch} is up to date`
+                : `Pulled ${event.commits_applied} commit(s) into ${event.branch}`,
+          },
+        });
+        break;
+      case 'FetchCompleted':
+        dispatch({
+          type: 'SET_GIT_TOAST',
+          toast: { kind: 'fetch', message: `Fetched from ${event.remote}` },
+        });
+        break;
+      case 'GitOperationFailed':
+        dispatch({
+          type: 'SET_GIT_TOAST',
+          toast: { kind: 'error', message: `${event.operation} failed: ${event.reason}` },
+        });
+        break;
       case 'MergeConflicts':
         dispatch({ type: 'SET_MERGE_CONFLICTS', files: event.files });
         break;
       case 'ConflictResolved':
         dispatch({ type: 'REMOVE_CONFLICT', filePath: event.file_path });
         break;
+
+      // --- File viewer / search ---
+      case 'FileContent':
+        dispatch({
+          type: 'SET_FILE_CONTENT',
+          path: event.path,
+          content: event.content,
+          language: event.language,
+          truncated: event.truncated,
+          sizeBytes: event.size_bytes,
+        });
+        break;
+      case 'FileReadError':
+        dispatch({ type: 'SET_FILE_ERROR', path: event.path, error: event.error });
+        break;
+      case 'SearchResults':
+        dispatch({
+          type: 'SET_SEARCH_RESULTS',
+          result: {
+            query: event.query,
+            matches: event.matches,
+            total_matches: event.total_matches,
+            files_searched: event.files_searched,
+            truncated: event.truncated,
+            duration_ms: event.duration_ms,
+          },
+        });
+        break;
+
+      default:
+        return assertNever(event);
     }
   }
+}
+
+/**
+ * Compile-time exhaustiveness gate. Adding a new `AppEvent` variant without
+ * a matching case above will fail TypeScript compilation here.
+ */
+function assertNever(value: never): never {
+  throw new Error(`Unhandled AppEvent variant: ${JSON.stringify(value)}`);
 }

--- a/frontend/src/core/events/terminalBus.ts
+++ b/frontend/src/core/events/terminalBus.ts
@@ -1,0 +1,38 @@
+// Terminal event bus — in-memory pub/sub for high-frequency PTY events.
+//
+// TerminalOutput arrives at ~60Hz per active session. Routing it through
+// React reducer state would invalidate the entire workspace subtree on each
+// chunk. Instead we keep a small module-level subscriber set and let
+// TerminalPane write directly to xterm.js.
+
+import type { AppEvent } from '../../types/protocol';
+
+export type TerminalEvent = Extract<
+  AppEvent,
+  { type: 'TerminalSessionCreated' | 'TerminalOutput' | 'TerminalSessionClosed' }
+>;
+
+type Handler = (event: TerminalEvent) => void;
+
+const handlers = new Set<Handler>();
+
+export function subscribeTerminalEvents(handler: Handler): () => void {
+  handlers.add(handler);
+  return () => {
+    handlers.delete(handler);
+  };
+}
+
+export function publishTerminalEvent(event: TerminalEvent): void {
+  for (const h of handlers) {
+    try {
+      h(event);
+    } catch (err) {
+      console.error('[terminalBus] handler threw', err);
+    }
+  }
+}
+
+export function _resetForTests(): void {
+  handlers.clear();
+}

--- a/frontend/src/panes/empty/EmptyPane.test.tsx
+++ b/frontend/src/panes/empty/EmptyPane.test.tsx
@@ -1,0 +1,35 @@
+// Pane smoke test — rendering EmptyPane must not throw. Pane components that
+// depend on AppContext are exercised separately; EmptyPane is context-free,
+// so this is a pure render check.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+import { EmptyPane } from './EmptyPane';
+
+afterEach(cleanup);
+
+describe('EmptyPane', () => {
+  it('renders the "choose a pane type" prompt', () => {
+    render(
+      <EmptyPane
+        pane={{ id: 'p1', kind: 'Empty', resource_id: null }}
+        workspaceId="w1"
+        focused={true}
+      />,
+    );
+    expect(screen.getByText(/choose a pane type/i)).toBeTruthy();
+  });
+
+  it('renders a button per pane option', () => {
+    render(
+      <EmptyPane
+        pane={{ id: 'p1', kind: 'Empty', resource_id: null }}
+        workspaceId="w1"
+        focused={false}
+      />,
+    );
+    // Terminal, SSH, AI Run, Browser, Git Status, Git History
+    expect(screen.getAllByRole('button')).toHaveLength(6);
+  });
+});

--- a/frontend/src/panes/file-viewer/FileViewerPane.tsx
+++ b/frontend/src/panes/file-viewer/FileViewerPane.tsx
@@ -1,24 +1,10 @@
 // FileViewerPane — read-only file viewer with line numbers (TERMINAL-005)
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { registerPane } from '../registry';
 import type { PaneProps } from '../registry';
 import { useSend } from '../../context/SendContext';
-
-interface FileContentEvent {
-  type: 'FileContent';
-  path: string;
-  content: string;
-  language: string;
-  truncated: boolean;
-  size_bytes: number;
-}
-
-interface FileReadErrorEvent {
-  type: 'FileReadError';
-  path: string;
-  error: string;
-}
+import { useAppState } from '../../context/AppContext';
 
 type State =
   | { status: 'empty' }
@@ -28,41 +14,32 @@ type State =
 
 export function FileViewerPane({ pane }: PaneProps) {
   const send = useSend();
-  const [state, setState] = useState<State>({ status: 'empty' });
-  const pathRef = useRef<string | null>(null);
+  const fileViewer = useAppState().fileViewer;
 
-  // Send ReadFile when resource_id changes
+  // Fire a ReadFile whenever the pane resource changes
   useEffect(() => {
     const path = pane.resource_id;
-    if (!path) {
-      setState({ status: 'empty' });
-      return;
-    }
-    pathRef.current = path;
-    setState({ status: 'loading', path });
+    if (!path) return;
     send({ type: 'ReadFile', path });
   }, [pane.resource_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Listen for file-viewer-event dispatched from App.tsx
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const event = (e as CustomEvent).detail as FileContentEvent | FileReadErrorEvent;
-      if (event.type === 'FileContent' && event.path === pathRef.current) {
-        setState({
-          status: 'loaded',
-          path: event.path,
-          content: event.content,
-          language: event.language,
-          truncated: event.truncated,
-          size_bytes: event.size_bytes,
-        });
-      } else if (event.type === 'FileReadError' && event.path === pathRef.current) {
-        setState({ status: 'error', path: event.path, error: event.error });
-      }
+  // Derive render state from the store. We only commit the server response
+  // when it matches this pane's resource — otherwise a concurrent viewer
+  // could clobber our view.
+  const state: State = useMemo(() => {
+    const path = pane.resource_id;
+    if (!path) return { status: 'empty' };
+    if (!fileViewer || fileViewer.path !== path) return { status: 'loading', path };
+    if ('error' in fileViewer) return { status: 'error', path, error: fileViewer.error };
+    return {
+      status: 'loaded',
+      path,
+      content: fileViewer.content,
+      language: fileViewer.language,
+      truncated: fileViewer.truncated,
+      size_bytes: fileViewer.size_bytes,
     };
-    window.addEventListener('file-viewer-event', handler);
-    return () => window.removeEventListener('file-viewer-event', handler);
-  }, []);
+  }, [pane.resource_id, fileViewer]);
 
   const containerStyle: React.CSSProperties = {
     flex: 1,

--- a/frontend/src/panes/search/SearchPane.tsx
+++ b/frontend/src/panes/search/SearchPane.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { registerPane } from '../registry';
 import type { PaneProps } from '../registry';
 import { useSend } from '../../context/SendContext';
+import { useAppState } from '../../context/AppContext';
 import type { SearchMatch } from '../../types/protocol';
 
 interface SearchResultsEvent {
@@ -206,6 +207,7 @@ function FileGroup({
 
 export function SearchPane(_props: PaneProps) {
   const send = useSend();
+  const storeResult = useAppState().searchResult;
   const [query, setQuery] = useState('');
   const [isRegex, setIsRegex] = useState(false);
   const [caseSensitive, setCaseSensitive] = useState(false);
@@ -233,18 +235,13 @@ export function SearchPane(_props: PaneProps) {
     });
   }
 
-  // Listen for search-results events dispatched from App.tsx
+  // Listen for search results via the store (C3). Only accept results for
+  // the query we last fired — concurrent searches can interleave.
   useEffect(() => {
-    const handler = (e: Event) => {
-      const event = (e as CustomEvent).detail as SearchResultsEvent;
-      // Only accept results for the query we last fired
-      if (event.query === activeQueryRef.current) {
-        setSearchState({ status: 'results', event });
-      }
-    };
-    window.addEventListener('search-results', handler);
-    return () => window.removeEventListener('search-results', handler);
-  }, []);
+    if (!storeResult) return;
+    if (storeResult.query !== activeQueryRef.current) return;
+    setSearchState({ status: 'results', event: { type: 'SearchResults', ...storeResult } });
+  }, [storeResult]);
 
   // Group matches by file
   const fileGroups: Map<string, SearchMatch[]> = (() => {

--- a/frontend/src/panes/terminal/TerminalPane.tsx
+++ b/frontend/src/panes/terminal/TerminalPane.tsx
@@ -7,6 +7,7 @@ import { useSend } from '../../context/SendContext';
 import { useAppState } from '../../context/AppContext';
 import { registerPane } from '../registry';
 import type { PaneProps } from '../registry';
+import { subscribeTerminalEvents } from '../../core/events/terminalBus';
 
 type SessionState = 'idle' | 'creating' | 'active' | 'lost' | 'restoring';
 
@@ -37,8 +38,7 @@ let globalListenerInstalled = false;
 function installGlobalListener() {
   if (globalListenerInstalled) return;
   globalListenerInstalled = true;
-  window.addEventListener('terminal-event', (e: Event) => {
-    const event = (e as CustomEvent).detail;
+  subscribeTerminalEvents((event) => {
     if (event.type === 'TerminalSessionCreated') {
       claimSession(event.workspace_id, event.session_id);
     }
@@ -237,8 +237,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
   // Listen for terminal output and close events (session-specific, not creation)
   useEffect(() => {
     if (!sessionId) return;
-    const handler = (e: Event) => {
-      const event = (e as CustomEvent).detail;
+    const handler = (event: Parameters<Parameters<typeof subscribeTerminalEvents>[0]>[0]) => {
       if (event.type === 'TerminalOutput' && event.session_id === sessionId) {
         xtermRef.current?.write(event.data);
 
@@ -287,8 +286,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
         setSessionState('lost');
       }
     };
-    window.addEventListener('terminal-event', handler);
-    return () => window.removeEventListener('terminal-event', handler);
+    return subscribeTerminalEvents(handler);
     // pane.id and pane.label are stable per component instance.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);

--- a/frontend/src/state/app-store.test.ts
+++ b/frontend/src/state/app-store.test.ts
@@ -1,0 +1,166 @@
+// M14 — one test per AppStoreAction variant.
+//
+// Adding a new action to `AppStoreAction` without a matching test here means
+// the `ACTIONS_COVERED` completeness guard below fails.
+
+import { describe, it, expect } from 'vitest';
+import {
+  appStoreReducer,
+  initialAppStore,
+  type AppStore,
+  type AppStoreAction,
+} from './app-store';
+import type { SessionSummary } from '../types/protocol';
+import type { WorkspaceSummary } from '../domain/workspace/types';
+
+const session = (id: string): SessionSummary => ({
+  id,
+  project_root: '/',
+  active_run: null,
+  run_count: 0,
+  started_at: 'now',
+});
+
+const workspace = (id: string): WorkspaceSummary => ({
+  id,
+  name: id,
+  root_path: '/',
+  mode: 'Terminal',
+  linked_session_id: null,
+  last_active_at: 'now',
+});
+
+// Tracks which action.type values have been exercised. A final test asserts
+// every discriminant in `AppStoreAction` is covered.
+const covered = new Set<AppStoreAction['type']>();
+function run(prev: AppStore, action: AppStoreAction): AppStore {
+  covered.add(action.type);
+  return appStoreReducer(prev, action);
+}
+
+describe('appStoreReducer', () => {
+  it('SET_CONNECTION_STATUS updates status only', () => {
+    const next = run(initialAppStore, { type: 'SET_CONNECTION_STATUS', status: 'connected' });
+    expect(next.connection.status).toBe('connected');
+    expect(next.connection.lastPong).toBe(initialAppStore.connection.lastPong);
+  });
+
+  it('SET_LAST_PONG stamps lastPong to now', () => {
+    const before = Date.now();
+    const next = run(initialAppStore, { type: 'SET_LAST_PONG' });
+    expect(next.connection.lastPong).toBeGreaterThanOrEqual(before);
+  });
+
+  it('SET_SESSIONS replaces the sessions map', () => {
+    const seeded = appStoreReducer(initialAppStore, { type: 'ADD_SESSION', session: session('old') });
+    const next = run(seeded, { type: 'SET_SESSIONS', sessions: [session('a'), session('b')] });
+    expect(Array.from(next.sessions.keys()).sort()).toEqual(['a', 'b']);
+  });
+
+  it('ADD_SESSION inserts without clobbering others', () => {
+    const a = appStoreReducer(initialAppStore, { type: 'ADD_SESSION', session: session('a') });
+    const b = run(a, { type: 'ADD_SESSION', session: session('b') });
+    expect(b.sessions.size).toBe(2);
+    expect(b.sessions.get('a')?.id).toBe('a');
+  });
+
+  it('REMOVE_SESSION drops the matching id', () => {
+    const seeded = appStoreReducer(initialAppStore, { type: 'SET_SESSIONS', sessions: [session('a'), session('b')] });
+    const next = run(seeded, { type: 'REMOVE_SESSION', sessionId: 'a' });
+    expect(next.sessions.has('a')).toBe(false);
+    expect(next.sessions.has('b')).toBe(true);
+  });
+
+  it('SET_WORKSPACES replaces the workspaces map', () => {
+    const next = run(initialAppStore, { type: 'SET_WORKSPACES', workspaces: [workspace('w1')] });
+    expect(next.workspaces.get('w1')?.name).toBe('w1');
+  });
+
+  it('ADD_WORKSPACE inserts a single entry', () => {
+    const next = run(initialAppStore, { type: 'ADD_WORKSPACE', workspace: workspace('w1') });
+    expect(next.workspaces.size).toBe(1);
+  });
+
+  it('REMOVE_WORKSPACE clears active id if it was the removed one', () => {
+    const seeded: AppStore = {
+      ...initialAppStore,
+      workspaces: new Map([['w1', workspace('w1')]]),
+      activeWorkspaceId: 'w1',
+    };
+    const next = run(seeded, { type: 'REMOVE_WORKSPACE', workspaceId: 'w1' });
+    expect(next.workspaces.has('w1')).toBe(false);
+    expect(next.activeWorkspaceId).toBeNull();
+  });
+
+  it('REMOVE_WORKSPACE preserves active id if different', () => {
+    const seeded: AppStore = {
+      ...initialAppStore,
+      workspaces: new Map([
+        ['w1', workspace('w1')],
+        ['w2', workspace('w2')],
+      ]),
+      activeWorkspaceId: 'w2',
+    };
+    const next = run(seeded, { type: 'REMOVE_WORKSPACE', workspaceId: 'w1' });
+    expect(next.activeWorkspaceId).toBe('w2');
+  });
+
+  it('SET_ACTIVE_WORKSPACE sets the id', () => {
+    const next = run(initialAppStore, { type: 'SET_ACTIVE_WORKSPACE', workspaceId: 'w1' });
+    expect(next.activeWorkspaceId).toBe('w1');
+  });
+
+  it('SET_ERROR writes an error message', () => {
+    const next = run(initialAppStore, { type: 'SET_ERROR', error: 'boom' });
+    expect(next.error).toBe('boom');
+  });
+
+  it('CLEAR_ERROR nulls the error', () => {
+    const seeded = appStoreReducer(initialAppStore, { type: 'SET_ERROR', error: 'boom' });
+    const next = run(seeded, { type: 'CLEAR_ERROR' });
+    expect(next.error).toBeNull();
+  });
+
+  it('TOGGLE_COMMAND_PALETTE flips the open flag', () => {
+    const once = run(initialAppStore, { type: 'TOGGLE_COMMAND_PALETTE' });
+    expect(once.commandPaletteOpen).toBe(true);
+    const twice = appStoreReducer(once, { type: 'TOGGLE_COMMAND_PALETTE' });
+    expect(twice.commandPaletteOpen).toBe(false);
+  });
+
+  it('OPEN_COMMAND_PALETTE sets the flag true', () => {
+    const next = run(initialAppStore, { type: 'OPEN_COMMAND_PALETTE' });
+    expect(next.commandPaletteOpen).toBe(true);
+  });
+
+  it('CLOSE_COMMAND_PALETTE sets the flag false', () => {
+    const open = appStoreReducer(initialAppStore, { type: 'OPEN_COMMAND_PALETTE' });
+    const next = run(open, { type: 'CLOSE_COMMAND_PALETTE' });
+    expect(next.commandPaletteOpen).toBe(false);
+  });
+
+  // Completeness gate: if new AppStoreAction variants are added without tests,
+  // this list must be extended. The `satisfies` check makes TS fail if any
+  // entry is NOT an AppStoreAction['type'].
+  it('covers every AppStoreAction variant', () => {
+    const expected = [
+      'SET_CONNECTION_STATUS',
+      'SET_LAST_PONG',
+      'SET_SESSIONS',
+      'ADD_SESSION',
+      'REMOVE_SESSION',
+      'SET_WORKSPACES',
+      'ADD_WORKSPACE',
+      'REMOVE_WORKSPACE',
+      'SET_ACTIVE_WORKSPACE',
+      'SET_ERROR',
+      'CLEAR_ERROR',
+      'TOGGLE_COMMAND_PALETTE',
+      'OPEN_COMMAND_PALETTE',
+      'CLOSE_COMMAND_PALETTE',
+    ] as const satisfies readonly AppStoreAction['type'][];
+    for (const tag of expected) {
+      expect(covered.has(tag), `action ${tag} should have a test`).toBe(true);
+    }
+  });
+});

--- a/frontend/src/state/workspace-store.test.ts
+++ b/frontend/src/state/workspace-store.test.ts
@@ -1,0 +1,460 @@
+// M14 — one test per WorkspaceAction variant.
+//
+// Covers every action in the discriminated union via a `covered` set with a
+// final completeness check. TS ensures the expected list only contains valid
+// action tags via `satisfies readonly WorkspaceAction['type'][]`.
+
+import { describe, it, expect } from 'vitest';
+import {
+  createWorkspaceStore,
+  workspaceReducer,
+  type WorkspaceAction,
+  type WorkspaceStore,
+} from './workspace-store';
+import type {
+  BranchInfo,
+  CommitEntry,
+  FileChange,
+  FileTreeEntry,
+  MergeConflictFile,
+  RestorableTerminalSession,
+  RunSummary,
+  StashEntry,
+  TerminalSessionSummary,
+} from '../types/protocol';
+
+const covered = new Set<WorkspaceAction['type']>();
+function run(prev: WorkspaceStore, action: WorkspaceAction): WorkspaceStore {
+  covered.add(action.type);
+  return workspaceReducer(prev, action);
+}
+
+const base = () => createWorkspaceStore('w1');
+
+const runSummary = (id: string): RunSummary => ({
+  id,
+  state: { type: 'Running' },
+  prompt_preview: 'p',
+  modified_file_count: 0,
+  started_at: 'now',
+  ended_at: null,
+  diff_stat: null,
+});
+
+const termSession = (id: string): TerminalSessionSummary => ({
+  session_id: id,
+  workspace_id: 'w1',
+  shell: 'bash',
+  cwd: '/',
+  created_at: 'now',
+  last_active_at: 'now',
+});
+
+const restorable = (id: string): RestorableTerminalSession => ({
+  session_id: id,
+  pane_id: 'pane-1',
+  cwd: '/',
+  last_active_at: 'now',
+});
+
+describe('workspaceReducer', () => {
+  it('SET_ACTIVE_SESSION', () => {
+    const next = run(base(), { type: 'SET_ACTIVE_SESSION', sessionId: 's1' });
+    expect(next.activeSession).toBe('s1');
+  });
+
+  it('SET_ACTIVE_RUN', () => {
+    const next = run(base(), { type: 'SET_ACTIVE_RUN', runId: 'r1' });
+    expect(next.activeRun).toBe('r1');
+  });
+
+  it('SET_RUN_STATE', () => {
+    const next = run(base(), { type: 'SET_RUN_STATE', runState: { type: 'Running' } });
+    expect(next.runState).toEqual({ type: 'Running' });
+  });
+
+  it('APPEND_OUTPUT appends up to the max', () => {
+    const once = run(base(), { type: 'APPEND_OUTPUT', line: 'a' });
+    expect(once.outputLines).toEqual(['a']);
+    let s = once;
+    for (let i = 0; i < 2500; i++) s = workspaceReducer(s, { type: 'APPEND_OUTPUT', line: `${i}` });
+    expect(s.outputLines.length).toBe(2000);
+    expect(s.outputLines.at(-1)).toBe('2499');
+  });
+
+  it('CLEAR_OUTPUT empties the buffer', () => {
+    const seeded = workspaceReducer(base(), { type: 'APPEND_OUTPUT', line: 'x' });
+    const next = run(seeded, { type: 'CLEAR_OUTPUT' });
+    expect(next.outputLines).toEqual([]);
+  });
+
+  it('SET_BLOCKING', () => {
+    const next = run(base(), { type: 'SET_BLOCKING', question: 'ok?', context: ['a'] });
+    expect(next.blocking).toEqual({ question: 'ok?', context: ['a'] });
+  });
+
+  it('CLEAR_BLOCKING', () => {
+    const seeded = workspaceReducer(base(), { type: 'SET_BLOCKING', question: 'q', context: [] });
+    const next = run(seeded, { type: 'CLEAR_BLOCKING' });
+    expect(next.blocking).toBeNull();
+  });
+
+  it('UPSERT_RUN / SET_RUNS', () => {
+    const one = run(base(), { type: 'UPSERT_RUN', run: runSummary('r1') });
+    expect(one.runs.get('r1')).toBeDefined();
+    const many = run(one, { type: 'SET_RUNS', runs: [runSummary('a'), runSummary('b')] });
+    expect(Array.from(many.runs.keys()).sort()).toEqual(['a', 'b']);
+  });
+
+  it('SELECT_RUN', () => {
+    const next = run(base(), { type: 'SELECT_RUN', runId: 'r1' });
+    expect(next.selectedRun).toBe('r1');
+  });
+
+  it('SET_DIFF caches by runId', () => {
+    const next = run(base(), {
+      type: 'SET_DIFF',
+      runId: 'r1',
+      stat: { files_changed: 1, insertions: 1, deletions: 0, file_stats: [] },
+      diff: 'diff-body',
+    });
+    expect(next.diffCache.get('r1')?.diff).toBe('diff-body');
+  });
+
+  it('SET_MERGE_CONFLICT / CLEAR_MERGE_CONFLICT', () => {
+    const set = run(base(), { type: 'SET_MERGE_CONFLICT', runId: 'r1', paths: ['a'] });
+    expect(set.mergeConflict?.paths).toEqual(['a']);
+    const clr = run(set, { type: 'CLEAR_MERGE_CONFLICT' });
+    expect(clr.mergeConflict).toBeNull();
+  });
+
+  it('ADD_TOOL_CALL / UPDATE_TOOL_RESULT — gated by activeRun', () => {
+    const seeded = workspaceReducer(base(), { type: 'SET_ACTIVE_RUN', runId: 'r1' });
+    const add = run(seeded, {
+      type: 'ADD_TOOL_CALL',
+      runId: 'r1',
+      toolCall: { tool_id: 't1', tool_name: 'bash', input_preview: 'ls', status: 'pending' },
+    });
+    expect(add.runToolCalls.get('t1')?.status).toBe('pending');
+    const res = run(add, {
+      type: 'UPDATE_TOOL_RESULT',
+      runId: 'r1',
+      toolId: 't1',
+      isError: false,
+      resultPreview: 'ok',
+    });
+    expect(res.runToolCalls.get('t1')?.status).toBe('ok');
+    // Non-active-run updates are ignored.
+    const ignored = workspaceReducer(res, {
+      type: 'ADD_TOOL_CALL',
+      runId: 'other',
+      toolCall: { tool_id: 'x', tool_name: 'y', input_preview: '', status: 'pending' },
+    });
+    expect(ignored.runToolCalls.has('x')).toBe(false);
+  });
+
+  it('SET_RUN_METRICS', () => {
+    const next = run(base(), {
+      type: 'SET_RUN_METRICS',
+      runId: 'r1',
+      metrics: { num_turns: 1, cost_usd: 0.1, input_tokens: 10, output_tokens: 20 },
+    });
+    expect(next.runMetrics?.num_turns).toBe(1);
+  });
+
+  it('SET_PREFLIGHT_ERROR', () => {
+    const next = run(base(), {
+      type: 'SET_PREFLIGHT_ERROR',
+      error: { reason: 'x', suggestion: 'y' },
+    });
+    expect(next.preflightError?.reason).toBe('x');
+  });
+
+  it('SET_STASHES', () => {
+    const stashes: StashEntry[] = [
+      { index: 0, message: 'm', branch: 'b', date: 'now' },
+    ];
+    const next = run(base(), { type: 'SET_STASHES', stashes });
+    expect(next.stashes).toHaveLength(1);
+  });
+
+  it('SET_STASH_FILES', () => {
+    const files: FileChange[] = [{ path: 'a', status: 'Modified' }];
+    const next = run(base(), { type: 'SET_STASH_FILES', stashIndex: 0, files });
+    expect(next.stashFiles.get(0)).toHaveLength(1);
+  });
+
+  it('SET_STASH_DIFF', () => {
+    const next = run(base(), {
+      type: 'SET_STASH_DIFF',
+      stashIndex: 0,
+      diff: 'body',
+      stat: null,
+    });
+    expect(next.stashDiffs.get('0')?.diff).toBe('body');
+  });
+
+  it('SET_DIRTY_WARNING / DISMISS_DIRTY_WARNING', () => {
+    const set = run(base(), {
+      type: 'SET_DIRTY_WARNING',
+      status: { staged: [], unstaged: [] },
+      session_id: 's1',
+      prompt: 'p',
+      mode: 'Free',
+    });
+    expect(set.dirtyWarning?.session_id).toBe('s1');
+    const clr = run(set, { type: 'DISMISS_DIRTY_WARNING' });
+    expect(clr.dirtyWarning).toBeNull();
+  });
+
+  it('SET_DIRTY_STATE', () => {
+    const next = run(base(), {
+      type: 'SET_DIRTY_STATE',
+      status: { staged: [], unstaged: [] },
+    });
+    expect(next.dirtyState).toEqual({ staged: [], unstaged: [] });
+  });
+
+  it('TOGGLE_STASH_DRAWER flips open flag', () => {
+    const once = run(base(), { type: 'TOGGLE_STASH_DRAWER' });
+    expect(once.stashDrawerOpen).toBe(true);
+    const twice = workspaceReducer(once, { type: 'TOGGLE_STASH_DRAWER' });
+    expect(twice.stashDrawerOpen).toBe(false);
+  });
+
+  it('SET_SIDEBAR_VIEW expands collapsed sidebar', () => {
+    const collapsed: WorkspaceStore = { ...base(), sidebarCollapsed: true };
+    const next = run(collapsed, { type: 'SET_SIDEBAR_VIEW', view: 'git' });
+    expect(next.activeSidebarView).toBe('git');
+    expect(next.sidebarCollapsed).toBe(false);
+  });
+
+  it('TOGGLE_SIDEBAR', () => {
+    const once = run(base(), { type: 'TOGGLE_SIDEBAR' });
+    expect(once.sidebarCollapsed).toBe(true);
+  });
+
+  it('SET_CHANGES_CONTEXT resets files', () => {
+    const seeded = workspaceReducer(base(), {
+      type: 'SET_CHANGED_FILES',
+      context: { mode: 'working' },
+      files: [{ path: 'a', status: 'Modified' }],
+    });
+    const next = run(seeded, { type: 'SET_CHANGES_CONTEXT', context: { mode: 'run', runId: 'r1' } });
+    expect(next.changedFiles).toBeNull();
+    expect(next.changesContext).toEqual({ mode: 'run', runId: 'r1' });
+  });
+
+  it('SET_CHANGED_FILES — gated by context match', () => {
+    const start = base();
+    const match = run(start, {
+      type: 'SET_CHANGED_FILES',
+      context: { mode: 'working' },
+      files: [{ path: 'a', status: 'Modified' }],
+    });
+    expect(match.changedFiles?.files).toHaveLength(1);
+    // Mismatched context (different mode) is dropped.
+    const mismatch = workspaceReducer(match, {
+      type: 'SET_CHANGED_FILES',
+      context: { mode: 'run', runId: 'x' },
+      files: [{ path: 'b', status: 'Modified' }],
+    });
+    expect(mismatch.changedFiles?.files[0]?.path).toBe('a');
+  });
+
+  it('SET_REPO_STATUS', () => {
+    const next = run(base(), {
+      type: 'SET_REPO_STATUS',
+      status: { branch: 'main', head: 'abc', clean: true, staged_count: 0, unstaged_count: 0 },
+    });
+    expect(next.repoStatus?.branch).toBe('main');
+  });
+
+  it('SET_COMMIT_HISTORY', () => {
+    const commits: CommitEntry[] = [
+      { hash: 'abc', message: 'm', author: 'a', date: 'now' },
+    ];
+    const next = run(base(), { type: 'SET_COMMIT_HISTORY', commits });
+    expect(next.commitHistory).toHaveLength(1);
+  });
+
+  it('SET_DIRECTORY', () => {
+    const entries: FileTreeEntry[] = [{ name: 'a', path: '/a', is_dir: false }];
+    const next = run(base(), { type: 'SET_DIRECTORY', path: '/', entries });
+    expect(next.explorerTree.get('/')).toHaveLength(1);
+  });
+
+  it('OPEN_DIFF / SET_DIFF_CONTENT / CLOSE_DIFF', () => {
+    const open = run(base(), { type: 'OPEN_DIFF', file: 'a' });
+    expect(open.diffPanel).toMatchObject({ open: true, file: 'a' });
+    const set = run(open, { type: 'SET_DIFF_CONTENT', file: 'a', diff: 'body', stat: null });
+    expect(set.diffPanel.diff).toBe('body');
+    // Mismatched file is ignored.
+    const mismatched = workspaceReducer(set, {
+      type: 'SET_DIFF_CONTENT',
+      file: 'other',
+      diff: 'nope',
+      stat: null,
+    });
+    expect(mismatched.diffPanel.diff).toBe('body');
+    const close = run(set, { type: 'CLOSE_DIFF' });
+    expect(close.diffPanel).toMatchObject({ open: false, file: null });
+  });
+
+  it('SET_DIFF_MODE', () => {
+    const next = run(base(), { type: 'SET_DIFF_MODE', mode: 'overlay' });
+    expect(next.diffPanel.mode).toBe('overlay');
+  });
+
+  it('SET_BRANCH_NAME', () => {
+    const seeded = workspaceReducer(base(), {
+      type: 'SET_REPO_STATUS',
+      status: { branch: 'old', head: 'h', clean: true, staged_count: 0, unstaged_count: 0 },
+    });
+    const next = run(seeded, { type: 'SET_BRANCH_NAME', name: 'feature' });
+    expect(next.currentBranch).toBe('feature');
+    expect(next.repoStatus?.branch).toBe('feature');
+  });
+
+  it('SET_BRANCH_LIST', () => {
+    const branches: BranchInfo[] = [
+      { name: 'main', is_head: true, upstream: null, last_commit_summary: null },
+    ];
+    const next = run(base(), { type: 'SET_BRANCH_LIST', branches, current: 'main' });
+    expect(next.branches).toHaveLength(1);
+    expect(next.currentBranch).toBe('main');
+  });
+
+  it('SET_GIT_TOAST', () => {
+    const next = run(base(), {
+      type: 'SET_GIT_TOAST',
+      toast: { kind: 'push', message: 'ok' },
+    });
+    expect(next.gitToast?.message).toBe('ok');
+  });
+
+  it('ADD / REMOVE / SET_TERMINAL_SESSIONS', () => {
+    const add = run(base(), { type: 'ADD_TERMINAL_SESSION', session: termSession('t1') });
+    expect(add.terminalSessions.size).toBe(1);
+    const set = run(add, {
+      type: 'SET_TERMINAL_SESSIONS',
+      sessions: [termSession('a'), termSession('b')],
+    });
+    expect(set.terminalSessions.size).toBe(2);
+    const del = run(set, { type: 'REMOVE_TERMINAL_SESSION', sessionId: 'a' });
+    expect(del.terminalSessions.has('a')).toBe(false);
+  });
+
+  it('SET_RESTORABLE_TERMINALS', () => {
+    const next = run(base(), {
+      type: 'SET_RESTORABLE_TERMINALS',
+      sessions: [restorable('r1')],
+    });
+    expect(next.restorableTerminals).toHaveLength(1);
+  });
+
+  it('SET_MERGE_CONFLICTS / REMOVE_CONFLICT', () => {
+    const files: MergeConflictFile[] = [
+      { path: 'a', ours: '', theirs: '', base: null },
+      { path: 'b', ours: '', theirs: '', base: null },
+    ];
+    const set = run(base(), { type: 'SET_MERGE_CONFLICTS', files });
+    expect(set.mergeConflicts).toHaveLength(2);
+    const del = run(set, { type: 'REMOVE_CONFLICT', filePath: 'a' });
+    expect(del.mergeConflicts.map((f) => f.path)).toEqual(['b']);
+  });
+
+  it('SET_FILE_CONTENT / SET_FILE_ERROR', () => {
+    const set = run(base(), {
+      type: 'SET_FILE_CONTENT',
+      path: 'f',
+      content: 'hello',
+      language: 'ts',
+      truncated: false,
+      sizeBytes: 5,
+    });
+    expect(set.fileViewer?.content).toBe('hello');
+    const err = run(set, { type: 'SET_FILE_ERROR', path: 'f', error: 'oops' });
+    expect(err.fileViewer?.error).toBe('oops');
+    expect(err.fileViewer?.content).toBeUndefined();
+  });
+
+  it('SET_SEARCH_RESULTS', () => {
+    const next = run(base(), {
+      type: 'SET_SEARCH_RESULTS',
+      result: {
+        query: 'q',
+        matches: [],
+        total_matches: 0,
+        files_searched: 0,
+        truncated: false,
+        duration_ms: 1,
+      },
+    });
+    expect(next.searchResult?.query).toBe('q');
+  });
+
+  it('unknown action returns state unchanged (default branch)', () => {
+    const start = base();
+    // @ts-expect-error — probing the default arm.
+    const next = workspaceReducer(start, { type: '__UNKNOWN__' });
+    expect(next).toBe(start);
+  });
+
+  // Completeness gate. `satisfies readonly WorkspaceAction['type'][]` means a
+  // stale entry (renamed/removed action) triggers a TS error at compile time.
+  it('covers every WorkspaceAction variant', () => {
+    const expected = [
+      'SET_ACTIVE_SESSION',
+      'SET_ACTIVE_RUN',
+      'SET_RUN_STATE',
+      'APPEND_OUTPUT',
+      'CLEAR_OUTPUT',
+      'SET_BLOCKING',
+      'CLEAR_BLOCKING',
+      'UPSERT_RUN',
+      'SET_RUNS',
+      'SELECT_RUN',
+      'SET_DIFF',
+      'SET_MERGE_CONFLICT',
+      'CLEAR_MERGE_CONFLICT',
+      'ADD_TOOL_CALL',
+      'UPDATE_TOOL_RESULT',
+      'SET_RUN_METRICS',
+      'SET_PREFLIGHT_ERROR',
+      'SET_STASHES',
+      'SET_STASH_FILES',
+      'SET_STASH_DIFF',
+      'SET_DIRTY_WARNING',
+      'DISMISS_DIRTY_WARNING',
+      'SET_DIRTY_STATE',
+      'TOGGLE_STASH_DRAWER',
+      'SET_SIDEBAR_VIEW',
+      'TOGGLE_SIDEBAR',
+      'SET_CHANGES_CONTEXT',
+      'SET_CHANGED_FILES',
+      'SET_REPO_STATUS',
+      'SET_COMMIT_HISTORY',
+      'SET_DIRECTORY',
+      'OPEN_DIFF',
+      'CLOSE_DIFF',
+      'SET_DIFF_CONTENT',
+      'SET_DIFF_MODE',
+      'SET_BRANCH_NAME',
+      'SET_BRANCH_LIST',
+      'SET_GIT_TOAST',
+      'ADD_TERMINAL_SESSION',
+      'REMOVE_TERMINAL_SESSION',
+      'SET_TERMINAL_SESSIONS',
+      'SET_RESTORABLE_TERMINALS',
+      'SET_MERGE_CONFLICTS',
+      'REMOVE_CONFLICT',
+      'SET_FILE_CONTENT',
+      'SET_FILE_ERROR',
+      'SET_SEARCH_RESULTS',
+    ] as const satisfies readonly WorkspaceAction['type'][];
+    for (const tag of expected) {
+      expect(covered.has(tag), `action ${tag} should have a test`).toBe(true);
+    }
+  });
+});

--- a/frontend/src/state/workspace-store.ts
+++ b/frontend/src/state/workspace-store.ts
@@ -1,18 +1,47 @@
-// Per-workspace state — scoped to a single workspace (M1-02)
+// Per-workspace state — scoped to a single workspace (M1-02, C3)
 
 import type {
+  BranchInfo,
   CommitEntry,
   DiffStat,
   DirtyStatus,
   FileChange,
   FileTreeEntry,
   MergeConflictFile,
+  PreflightError,
+  RestorableTerminalSession,
+  RunMetrics,
   RunMode,
   RunState,
   RunSummary,
+  SearchMatch,
   StashEntry,
+  ToolCall,
 } from '../types/protocol';
 import type { TerminalSessionSummary } from '../types/protocol';
+
+export interface SearchResult {
+  query: string;
+  matches: SearchMatch[];
+  total_matches: number;
+  files_searched: number;
+  truncated: boolean;
+  duration_ms: number;
+}
+
+export interface FileViewerState {
+  path: string;
+  content?: string;
+  language?: string;
+  truncated?: boolean;
+  size_bytes?: number;
+  error?: string;
+}
+
+export interface GitToast {
+  kind: 'push' | 'pull' | 'fetch' | 'error';
+  message: string;
+}
 
 export interface WorkspaceStore {
   workspaceId: string;
@@ -28,11 +57,17 @@ export interface WorkspaceStore {
   diffCache: Map<string, { stat: DiffStat; diff: string }>;
   mergeConflict: { runId: string; paths: string[] } | null;
 
+  // Run telemetry (TERMINAL-055)
+  runToolCalls: Map<string, ToolCall>;
+  runMetrics: RunMetrics | null;
+  preflightError: PreflightError | null;
+
   // Stash / dirty
   stashes: StashEntry[];
   stashFiles: Map<number, FileChange[]>;
   stashDiffs: Map<string, { diff: string; stat: DiffStat | null }>;
   dirtyWarning: { status: DirtyStatus; session_id: string; prompt: string; mode: RunMode } | null;
+  dirtyState: DirtyStatus | null;
   stashDrawerOpen: boolean;
 
   // Sidebar layout
@@ -47,11 +82,21 @@ export interface WorkspaceStore {
   explorerTree: Map<string, FileTreeEntry[]>;
   diffPanel: { open: boolean; mode: 'split' | 'overlay' | 'inline'; file: string | null; diff: string | null; stat: DiffStat | null };
 
+  // Git branches
+  branches: BranchInfo[];
+  currentBranch: string | null;
+  gitToast: GitToast | null;
+
   // Terminal pane sessions
   terminalSessions: Map<string, TerminalSessionSummary>;
+  restorableTerminals: RestorableTerminalSession[];
 
   // Merge conflicts (M5-05)
   mergeConflicts: MergeConflictFile[];
+
+  // File viewer / search (TERMINAL-005/006)
+  fileViewer: FileViewerState | null;
+  searchResult: SearchResult | null;
 }
 
 export interface RepoStatus {
@@ -76,10 +121,14 @@ export function createWorkspaceStore(workspaceId: string): WorkspaceStore {
     selectedRun: null,
     diffCache: new Map(),
     mergeConflict: null,
+    runToolCalls: new Map(),
+    runMetrics: null,
+    preflightError: null,
     stashes: [],
     stashFiles: new Map(),
     stashDiffs: new Map(),
     dirtyWarning: null,
+    dirtyState: null,
     stashDrawerOpen: false,
     activeSidebarView: 'changes',
     sidebarCollapsed: false,
@@ -90,13 +139,22 @@ export function createWorkspaceStore(workspaceId: string): WorkspaceStore {
     explorerTree: new Map(),
     diffPanel: {
       open: false,
-      mode: (localStorage.getItem('diff-mode') as 'split' | 'overlay' | 'inline') || 'split',
+      mode:
+        (typeof localStorage !== 'undefined'
+          ? (localStorage.getItem('diff-mode') as 'split' | 'overlay' | 'inline')
+          : null) || 'split',
       file: null,
       diff: null,
       stat: null,
     },
+    branches: [],
+    currentBranch: null,
+    gitToast: null,
     terminalSessions: new Map(),
+    restorableTerminals: [],
     mergeConflicts: [],
+    fileViewer: null,
+    searchResult: null,
   };
 }
 
@@ -114,11 +172,16 @@ export type WorkspaceAction =
   | { type: 'SET_DIFF'; runId: string; stat: DiffStat; diff: string }
   | { type: 'SET_MERGE_CONFLICT'; runId: string; paths: string[] }
   | { type: 'CLEAR_MERGE_CONFLICT' }
+  | { type: 'ADD_TOOL_CALL'; runId: string; toolCall: ToolCall }
+  | { type: 'UPDATE_TOOL_RESULT'; runId: string; toolId: string; isError: boolean; resultPreview: string }
+  | { type: 'SET_RUN_METRICS'; runId: string; metrics: RunMetrics }
+  | { type: 'SET_PREFLIGHT_ERROR'; error: PreflightError | null }
   | { type: 'SET_STASHES'; stashes: StashEntry[] }
   | { type: 'SET_STASH_FILES'; stashIndex: number; files: FileChange[] }
   | { type: 'SET_STASH_DIFF'; stashIndex: number; diff: string; stat: DiffStat | null }
   | { type: 'SET_DIRTY_WARNING'; status: DirtyStatus; session_id: string; prompt: string; mode: RunMode }
   | { type: 'DISMISS_DIRTY_WARNING' }
+  | { type: 'SET_DIRTY_STATE'; status: DirtyStatus }
   | { type: 'TOGGLE_STASH_DRAWER' }
   | { type: 'SET_SIDEBAR_VIEW'; view: WorkspaceStore['activeSidebarView'] }
   | { type: 'TOGGLE_SIDEBAR' }
@@ -131,11 +194,25 @@ export type WorkspaceAction =
   | { type: 'CLOSE_DIFF' }
   | { type: 'SET_DIFF_CONTENT'; file: string; diff: string; stat: DiffStat | null }
   | { type: 'SET_DIFF_MODE'; mode: WorkspaceStore['diffPanel']['mode'] }
+  | { type: 'SET_BRANCH_NAME'; name: string }
+  | { type: 'SET_BRANCH_LIST'; branches: BranchInfo[]; current: string | null }
+  | { type: 'SET_GIT_TOAST'; toast: GitToast | null }
   | { type: 'ADD_TERMINAL_SESSION'; session: TerminalSessionSummary }
   | { type: 'REMOVE_TERMINAL_SESSION'; sessionId: string }
   | { type: 'SET_TERMINAL_SESSIONS'; sessions: TerminalSessionSummary[] }
+  | { type: 'SET_RESTORABLE_TERMINALS'; sessions: RestorableTerminalSession[] }
   | { type: 'SET_MERGE_CONFLICTS'; files: MergeConflictFile[] }
-  | { type: 'REMOVE_CONFLICT'; filePath: string };
+  | { type: 'REMOVE_CONFLICT'; filePath: string }
+  | {
+      type: 'SET_FILE_CONTENT';
+      path: string;
+      content: string;
+      language: string;
+      truncated: boolean;
+      sizeBytes: number;
+    }
+  | { type: 'SET_FILE_ERROR'; path: string; error: string }
+  | { type: 'SET_SEARCH_RESULTS'; result: SearchResult };
 
 export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction): WorkspaceStore {
   switch (action.type) {
@@ -192,6 +269,32 @@ export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction)
     case 'CLEAR_MERGE_CONFLICT':
       return { ...state, mergeConflict: null };
 
+    case 'ADD_TOOL_CALL': {
+      if (action.runId !== state.activeRun) return state;
+      const runToolCalls = new Map(state.runToolCalls);
+      runToolCalls.set(action.toolCall.tool_id, action.toolCall);
+      return { ...state, runToolCalls };
+    }
+
+    case 'UPDATE_TOOL_RESULT': {
+      if (action.runId !== state.activeRun) return state;
+      const existing = state.runToolCalls.get(action.toolId);
+      if (!existing) return state;
+      const runToolCalls = new Map(state.runToolCalls);
+      runToolCalls.set(action.toolId, {
+        ...existing,
+        status: action.isError ? 'error' : 'ok',
+        result_preview: action.resultPreview,
+      });
+      return { ...state, runToolCalls };
+    }
+
+    case 'SET_RUN_METRICS':
+      return { ...state, runMetrics: action.metrics };
+
+    case 'SET_PREFLIGHT_ERROR':
+      return { ...state, preflightError: action.error };
+
     case 'SET_STASHES':
       return { ...state, stashes: action.stashes };
 
@@ -220,6 +323,9 @@ export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction)
 
     case 'DISMISS_DIRTY_WARNING':
       return { ...state, dirtyWarning: null };
+
+    case 'SET_DIRTY_STATE':
+      return { ...state, dirtyState: action.status };
 
     case 'TOGGLE_STASH_DRAWER':
       return { ...state, stashDrawerOpen: !state.stashDrawerOpen };
@@ -265,6 +371,19 @@ export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction)
     case 'SET_DIFF_MODE':
       return { ...state, diffPanel: { ...state.diffPanel, mode: action.mode } };
 
+    case 'SET_BRANCH_NAME':
+      return {
+        ...state,
+        repoStatus: state.repoStatus ? { ...state.repoStatus, branch: action.name } : null,
+        currentBranch: action.name,
+      };
+
+    case 'SET_BRANCH_LIST':
+      return { ...state, branches: action.branches, currentBranch: action.current };
+
+    case 'SET_GIT_TOAST':
+      return { ...state, gitToast: action.toast };
+
     case 'ADD_TERMINAL_SESSION': {
       const terminalSessions = new Map(state.terminalSessions);
       terminalSessions.set(action.session.session_id, action.session);
@@ -283,6 +402,9 @@ export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction)
       return { ...state, terminalSessions };
     }
 
+    case 'SET_RESTORABLE_TERMINALS':
+      return { ...state, restorableTerminals: action.sessions };
+
     case 'SET_MERGE_CONFLICTS':
       return { ...state, mergeConflicts: action.files };
 
@@ -291,6 +413,24 @@ export function workspaceReducer(state: WorkspaceStore, action: WorkspaceAction)
         ...state,
         mergeConflicts: state.mergeConflicts.filter((f) => f.path !== action.filePath),
       };
+
+    case 'SET_FILE_CONTENT':
+      return {
+        ...state,
+        fileViewer: {
+          path: action.path,
+          content: action.content,
+          language: action.language,
+          truncated: action.truncated,
+          size_bytes: action.sizeBytes,
+        },
+      };
+
+    case 'SET_FILE_ERROR':
+      return { ...state, fileViewer: { path: action.path, error: action.error } };
+
+    case 'SET_SEARCH_RESULTS':
+      return { ...state, searchResult: action.result };
 
     default:
       return state;


### PR DESCRIPTION
## Summary

Closes every open issue carrying the `opus` label in one branch.

### Fixed issues

| # | Title | Area |
|---|-------|------|
| #66 | C3 — EventRouter ignores ~20 protocol events | frontend |
| #81 | M12 — docs/ describes a CLI that is not the current app | docs |
| #83 | M14 — Frontend has almost no tests | frontend tests |
| #85 | M16 — Frontend Docker image hardcodes VITE_DAEMON_WS_URL | infra |
| #86 | M17 — Worktree cleanup is metadata-only | backend |
| #88 | Minor2 — Protocol roundtrip tests missing for many variants | backend |
| #93 | Minor7 — Replace file-wide `#![allow(dead_code)]` | backend |
| #98 | C5b — Wire workspace persistence into dispatcher + startup recovery | backend |
| #100 | M5b — Per-client active workspace map | backend |
| #101 | M5c — Audit broadcasts — route workspace-scoped events via `broadcast_workspace` | backend |
| #103 | Minor3b — Introduce `ConcurrencyGuard` / `ActiveRunGuard` (RAII) | backend |

### Key changes

**Backend**
- New `crates/terminal-daemon/src/guards.rs` — RAII `ConcurrencyGuard` / `ActiveRunGuard`, used in `dispatcher.rs` in place of manual `insert`/`remove` cleanup (#103).
- `DaemonContext` now carries a per-client active-workspace map (#100); `find_active_project_root` is client-scoped.
- Every dispatcher call site audited — workspace-scoped events go through `broadcast_workspace` (#101).
- `WorkspaceDispatcher` + `start_server()` persist workspaces on mutation and reload them on boot (#98).
- `persistence::delete_worktree` now calls `git_engine::worktree_remove` and `start_server` runs `reconcile_worktrees` to prune orphan metadata (#86).
- `protocol/v1.rs` — roundtrip tests for every `AppCommand` and `AppEvent` variant (#88).
- `persistence.rs` — file-wide `#![allow(dead_code)]` removed, replaced with narrow, documented allows (#93).

**Frontend**
- `core/events/eventRouter.ts` — every `AppEvent` variant has an explicit case. `assertNever` in the default arm is the compile-time guarantee (#66).
- `state/workspace-store.ts` + `context/AppContext.tsx` extended with `branches`, `fileViewer`, `searchResult`, `gitToast`, `dirtyState` and matching actions. `FileViewerPane`, `SearchPane`, `CommandPalette`, `TerminalPane` refactored to read from the store — no more `window.dispatchEvent` for protocol events (#66).
- New `core/daemon/resolveDaemonWsUrl.ts` — runtime WS URL resolution: Tauri > `window.__TERMINAL_CONFIG__` > same-origin `/ws`. `VITE_DAEMON_WS_URL` removed from compose and Dockerfile (#85).
- New `core/events/terminalBus.ts` — module-level pub/sub for high-frequency terminal output (avoids per-frame React state invalidation).
- Tests (#83):
  - `core/events/eventRouter.test.ts` — exhaustive `Record<AppEvent['type'], AppEvent>` samples.
  - `state/app-store.test.ts` / `workspace-store.test.ts` — one test per action, with completeness gates.
  - `core/commands/commandBus.test.ts` — forwarding contract + singleton.
  - `core/daemon/resolveDaemonWsUrl.test.ts` — precedence rules.
  - `panes/empty/EmptyPane.test.tsx` — render smoke test.
  - `test:coverage` script + `frontend/TESTING.md` conventions.

**Docs (#81)**
- Rewrote `docs/architecture.md` to describe the shipped Tauri + daemon app (was stale Portuguese `cc …` CLI design).
- Rewrote `docs/git-flow.md` to cover the daemon's git surface and the panes that consume it.
- New `docs/bin-cc.md` — holds the legacy `cc` shell helper docs, clearly labelled as optional.
- Refreshed `docs/next-steps.md` (roadmap, `./run.sh` / `./release.sh` references).
- Cross-linked from `README.md` and `CLAUDE.md`. Grep confirms no lingering `.cc-terminal.yml` references.

## Test plan

- [x] `cargo check -p terminal-core -p terminal-daemon` — clean
- [x] `cd frontend && npm run build` — typechecks + builds
- [x] `cd frontend && npm run test` — 7 files, 74 tests passing
- [ ] CI Rust test suite
- [ ] Verify PR checks pass on GitHub
