### PR TITLE
Close remaining gaps: worktree leak on close, ioctl error log, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,16 @@ Key domain groups:
 
 | Milestone | Issues | Status |
 |-----------|--------|--------|
-| M1 Foundation | #12, #15, #19, #24, #28 | ⚠️ Partial (#24 per-client workspace tracking pending #99) |
+| M1 Foundation | #12, #15, #19, #24, #28 | ✅ Implemented (per-client active workspace landed via #99/#100/#101) |
 | M2 Panes | #10, #11, #13, #18, #22 | ✅ Implemented |
 | M3 Modes | #14, #16, #17 | ✅ Implemented |
-| M4 Terminal | #20, #21, #23, #26, #27, #38 | ⚠️ Partial (#38 restore affordance pending #96) |
-| M5 Git | #25, #29, #30, #36, #37 | ✅ Implemented |
+| M4 Terminal | #20, #21, #23, #26, #27, #38 | ✅ Implemented (restore API + UI landed via #94/#95/#96) |
+| M5 Git | #25, #29, #30, #36, #37 | ✅ Implemented (stash pop/apply/drop included) |
 | M6 Browser | #31, #32 | ✅ Implemented |
 | M7 Polish | #33, #34, #35 | ✅ Implemented |
+| M11 Build tooling | — | ✅ `Makefile`, `run.sh`, `release.sh` |
+| M14 Frontend tests | — | ✅ Vitest suite (stores, eventRouter, components) |
+| M16 Runtime WS URL | — | ✅ Resolved via `resolveDaemonWsUrl` |
 
 ## Commit Messages
 

--- a/crates/terminal-daemon/src/dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatcher.rs
@@ -1308,49 +1308,46 @@ impl Dispatcher {
             // --- Stash mutations (M4) ---
 
             AppCommand::PopStash { index } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::stash_pop(&root, index).await {
-                        Ok(had_conflicts) => {
-                            let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx.send(AppEvent::Error {
-                                code: "STASH_FAILED".into(),
-                                message: e.to_string(),
-                            }).await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::stash_pop(&root, index).await {
+                    Ok(had_conflicts) => {
+                        let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx.send(AppEvent::Error {
+                            code: "STASH_FAILED".into(),
+                            message: e.to_string(),
+                        }).await;
                     }
                 }
             }
 
             AppCommand::ApplyStash { index } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::stash_apply(&root, index).await {
-                        Ok(had_conflicts) => {
-                            let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx.send(AppEvent::Error {
-                                code: "STASH_FAILED".into(),
-                                message: e.to_string(),
-                            }).await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::stash_apply(&root, index).await {
+                    Ok(had_conflicts) => {
+                        let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx.send(AppEvent::Error {
+                            code: "STASH_FAILED".into(),
+                            message: e.to_string(),
+                        }).await;
                     }
                 }
             }
 
             AppCommand::DropStash { index } => {
-                if let Some(root) = self.find_active_project_root().await {
-                    match crate::git_engine::stash_drop(&root, index).await {
-                        Ok(()) => {
-                            let _ = reply_tx.send(AppEvent::StashDropped { index }).await;
-                        }
-                        Err(e) => {
-                            let _ = reply_tx.send(AppEvent::Error {
-                                code: "STASH_FAILED".into(),
-                                message: e.to_string(),
-                            }).await;
-                        }
+                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                match crate::git_engine::stash_drop(&root, index).await {
+                    Ok(()) => {
+                        let _ = reply_tx.send(AppEvent::StashDropped { index }).await;
+                    }
+                    Err(e) => {
+                        let _ = reply_tx.send(AppEvent::Error {
+                            code: "STASH_FAILED".into(),
+                            message: e.to_string(),
+                        }).await;
                     }
                 }
             }

--- a/crates/terminal-daemon/src/dispatchers/workspace_dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatchers/workspace_dispatcher.rs
@@ -72,7 +72,7 @@ impl WorkspaceDispatcher {
 
             AppCommand::CloseWorkspace { workspace_id } => {
                 let removed = self.ctx.workspaces.lock().await.remove(&workspace_id);
-                if removed.is_some() {
+                if let Some(ws) = removed {
                     // Remove workspace channel
                     self.ctx.workspace_channels.lock().await.remove(&workspace_id);
                     // Scrub every client's active pointer that targeted this one (M5b).
@@ -80,6 +80,11 @@ impl WorkspaceDispatcher {
                         let mut active = self.ctx.active_workspaces.lock().await;
                         active.retain(|_, wid| *wid != workspace_id);
                     }
+                    // Physically prune worktrees whose repo_root matches this
+                    // workspace (#86 M17). Previously the dirs were left on disk
+                    // until the next daemon restart, which could leak gigabytes
+                    // for long-lived installations.
+                    prune_workspace_worktrees(&self.ctx, &ws.root_path).await;
                     if let Err(e) = self.ctx.persistence.delete_workspace(workspace_id) {
                         warn!("Failed to delete persisted workspace {}: {}", workspace_id, e);
                     }
@@ -132,6 +137,57 @@ impl WorkspaceDispatcher {
             _ => {
                 warn!("WorkspaceDispatcher received non-workspace command");
             }
+        }
+    }
+}
+
+/// Remove every worktree dir whose metadata has a `repo_root` under the given
+/// workspace root, plus its metadata file. Best-effort: individual failures are
+/// logged but do not block workspace close. Shared with the startup prune pass
+/// in `lib.rs` in spirit, but scoped to one workspace.
+async fn prune_workspace_worktrees(ctx: &DaemonContext, workspace_root: &std::path::Path) {
+    let metas = match ctx.persistence.list_worktree_metas() {
+        Ok(m) => m,
+        Err(e) => {
+            warn!("CloseWorkspace: list_worktree_metas failed: {}", e);
+            return;
+        }
+    };
+
+    // Canonicalize once so `/foo` and `/foo/` and `/./foo` all compare equal.
+    let canonical_ws = workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf());
+
+    for (run_id, meta) in metas {
+        let Some(repo_root) = meta.repo_root.as_ref() else {
+            continue;
+        };
+        let canonical_repo = repo_root
+            .canonicalize()
+            .unwrap_or_else(|_| repo_root.clone());
+        if canonical_repo != canonical_ws {
+            continue;
+        }
+
+        if meta.worktree_path.exists() {
+            if let Err(e) =
+                crate::git_engine::worktree_remove(repo_root, &meta.worktree_path).await
+            {
+                warn!(
+                    "CloseWorkspace: worktree_remove failed for run {} ({:?}): {}",
+                    run_id, meta.worktree_path, e
+                );
+                // Fall through to metadata deletion anyway — otherwise a
+                // permanently-failing remove would leak the meta forever.
+            }
+        }
+
+        if let Err(e) = ctx.persistence.delete_worktree_meta(run_id) {
+            warn!(
+                "CloseWorkspace: delete_worktree_meta failed for run {}: {}",
+                run_id, e
+            );
         }
     }
 }

--- a/crates/terminal-daemon/src/pty/manager.rs
+++ b/crates/terminal-daemon/src/pty/manager.rs
@@ -146,14 +146,23 @@ impl PtyManager {
         let master_raw = master_fd.as_raw_fd();
         let slave_raw = slave_fd.as_raw_fd();
 
-        // Set initial window size on master.
+        // Set initial window size on master. Failure is non-fatal (the subsequent
+        // resize from the frontend will correct it), but we log so silent
+        // misbehavior (e.g. tiny initial size) is diagnosable.
         let ws = nix::libc::winsize {
             ws_row: 40,
             ws_col: 120,
             ws_xpixel: 0,
             ws_ypixel: 0,
         };
-        unsafe { nix::libc::ioctl(master_raw, nix::libc::TIOCSWINSZ, &ws) };
+        let rc = unsafe { nix::libc::ioctl(master_raw, nix::libc::TIOCSWINSZ, &ws) };
+        if rc != 0 {
+            warn!(
+                "initial TIOCSWINSZ failed on master fd {}: {}",
+                master_raw,
+                std::io::Error::last_os_error()
+            );
+        }
 
         // Build the command. pre_exec sets up the child side of the PTY.
         let mut cmd = Command::new(&shell_path);


### PR DESCRIPTION
- #86 M17: prune workspace worktrees on CloseWorkspace
  Previously on-disk worktree dirs were only cleaned at daemon restart
  (via lib.rs prune) or explicit revert/merge. Closing a workspace with
  dangling worktrees leaked their dirs. Now we scan worktree metas whose
  repo_root matches the workspace root, git-worktree-remove them, and
  delete their metadata. Best-effort: individual failures are logged.

- #72 M3: log initial TIOCSWINSZ failure
  The initial winsize ioctl during PTY spawn ignored its return value.
  The subsequent resize from the frontend usually masks a failure, but
  silent failure meant a tiny default window on unusual TTY stacks was
  undiagnosable. Now a non-zero rc emits a warn! with errno.

- #92 Minor6: CLAUDE.md milestone table was overstated/understated
  M1 was flagged Partial pending #99, which has since landed (via #107).
  M4 was flagged Partial pending #96, which has since landed. Added
  M11/M14/M16 rows for build tooling, frontend tests, and runtime WS URL
  resolution — all implemented but invisible in the table.