### PR TITLE
Fix: Open button on WelcomeScreen does nothing (zombie WS close stomps wsRef)

### DIFF
--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useWebSocket } from './useWebSocket';
+
+// Minimal fake WebSocket that lets tests drive open/close/message events.
+class FakeSocket {
+  static OPEN = 1;
+  static instances: FakeSocket[] = [];
+  readyState = 0; // CONNECTING
+  onopen: ((e?: unknown) => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: ((e: { code: number; reason: string }) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  sent: string[] = [];
+  url: string;
+  constructor(url: string) {
+    this.url = url;
+    FakeSocket.instances.push(this);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    // Real browsers fire close asynchronously; the race we're testing depends
+    // on that delay. Do NOT fire it synchronously here.
+  }
+  fireOpen() {
+    this.readyState = FakeSocket.OPEN;
+    this.onopen?.();
+  }
+  fireMessage(data: string) {
+    this.onmessage?.({ data });
+  }
+  fireClose() {
+    this.readyState = 3; // CLOSED
+    this.onclose?.({ code: 1000, reason: '' });
+  }
+}
+
+describe('useWebSocket', () => {
+  const originalWS = globalThis.WebSocket;
+  beforeEach(() => {
+    FakeSocket.instances = [];
+    // Replace WebSocket constructor + static fields used by the hook.
+    (globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+      FakeSocket as unknown as typeof WebSocket;
+  });
+  afterEach(() => {
+    (globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket = originalWS;
+  });
+
+  it('does not drop into queue when a replaced socket closes after reconnect', () => {
+    // Regression: when url/token change, a new socket is created while the
+    // previous one is still closing. The old socket's delayed `onclose`
+    // used to nullify `wsRef.current`, causing every subsequent `send` to
+    // fall through to the pending-command queue forever — the user sees
+    // "nothing happens" when clicking Open on the WelcomeScreen.
+    const onEvent = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ url, token }) => useWebSocket({ url, token, onEvent }),
+      { initialProps: { url: 'ws://old/ws', token: 'old-token' } },
+    );
+
+    // First socket created. Simulate stale URL: don't open it yet.
+    expect(FakeSocket.instances).toHaveLength(1);
+    const oldWs = FakeSocket.instances[0];
+
+    // URL+token change (Tauri detectAndConnect resolves real port).
+    act(() => {
+      rerender({ url: 'ws://new/ws', token: 'new-token' });
+    });
+
+    // New socket created. Old one is closing but onclose hasn't fired yet.
+    expect(FakeSocket.instances).toHaveLength(2);
+    const newWs = FakeSocket.instances[1];
+
+    // New socket authenticates successfully.
+    act(() => {
+      newWs.fireOpen();
+      newWs.fireMessage(JSON.stringify({ type: 'AuthSuccess' }));
+    });
+    expect(result.current.status).toBe('connected');
+
+    // Now the OLD socket finally closes (network finished tearing it down).
+    // Before the fix this nullified wsRef.current and set status=disconnected.
+    act(() => {
+      oldWs.fireClose();
+    });
+
+    // Status must stay 'connected' — the old socket is a zombie.
+    expect(result.current.status).toBe('connected');
+
+    // And `send` must reach the new socket, not the pending-command queue.
+    act(() => {
+      result.current.send({ type: 'StartSession', project_root: '/tmp' });
+    });
+    expect(newWs.sent).toContainEqual(
+      JSON.stringify({ type: 'StartSession', project_root: '/tmp' }),
+    );
+  });
+
+  it('sends commands immediately when socket is open', () => {
+    const onEvent = vi.fn();
+    const { result } = renderHook(() =>
+      useWebSocket({ url: 'ws://daemon/ws', token: 't', onEvent }),
+    );
+    const ws = FakeSocket.instances[0];
+    act(() => {
+      ws.fireOpen();
+      ws.fireMessage(JSON.stringify({ type: 'AuthSuccess' }));
+    });
+    act(() => {
+      result.current.send({ type: 'Ping' });
+    });
+    expect(ws.sent).toContainEqual(JSON.stringify({ type: 'Ping' }));
+  });
+});

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -49,15 +49,29 @@ export function useWebSocket({ url, token, onEvent }: UseWebSocketOptions) {
     debug('[WS] Connecting to', url);
     setStatus('connecting');
     const ws = new WebSocket(url);
+    // Close any previous socket before replacing the ref. Without this, the
+    // old socket's close event fires later (see `isCurrent` guards below) —
+    // and even with the guards, leaving it open leaks a connection.
+    if (wsRef.current && wsRef.current !== ws) {
+      try { wsRef.current.close(); } catch { /* ignore */ }
+    }
     wsRef.current = ws;
 
+    // A socket might close/message AFTER it was replaced (e.g. url/token
+    // changed → new socket created → old socket closes later). Without this
+    // guard the old socket's `onclose` would nullify `wsRef.current` even
+    // though it now points to the fresh socket, silently breaking `send`.
+    const isCurrent = () => wsRef.current === ws;
+
     ws.onopen = () => {
+      if (!isCurrent()) return;
       debug('[WS] Connected, sending auth');
       setStatus('authenticating');
       ws.send(JSON.stringify({ type: 'Auth', token }));
     };
 
     ws.onmessage = (event) => {
+      if (!isCurrent()) return;
       if (import.meta.env.DEV && !event.data.includes('TerminalOutput')) {
         debug('[WS] Received:', event.data);
       }
@@ -82,6 +96,7 @@ export function useWebSocket({ url, token, onEvent }: UseWebSocketOptions) {
 
     ws.onclose = (ev) => {
       debug('[WS] Closed:', ev.code, ev.reason);
+      if (!isCurrent()) return;
       setStatus('disconnected');
       wsRef.current = null;
 
@@ -98,6 +113,7 @@ export function useWebSocket({ url, token, onEvent }: UseWebSocketOptions) {
     };
 
     ws.onerror = (err) => {
+      if (!isCurrent()) return;
       console.error('[WS] Error:', err);
       ws.close();
     };


### PR DESCRIPTION
When the daemon URL resolves (Tauri detectAndConnect → setDaemonUrl) after
the hook already created a socket against the localStorage-cached URL, the
effect cleans up the old socket and creates a new one. The old socket's
`close` event fires asynchronously — AFTER the new socket is already in
`wsRef.current`. The old socket's `onclose` handler unconditionally
nullified `wsRef.current` and flipped status to 'disconnected', but the
AuthSuccess from the new socket had already set status='connected', so the
UI still rendered the WelcomeScreen. Every subsequent `send()` then saw
`wsRef.current === null` and silently routed the command to the pending
queue — the user clicks Open and nothing happens.

Guard the four socket handlers (onopen/onmessage/onclose/onerror) with an
`isCurrent()` check so a replaced socket's delayed events can't mutate
shared state. Also close any lingering socket in `connect()` before
overwriting the ref, so we don't leak a zombie connection.

Includes a regression test that reproduces the race with fake sockets.