### PR TITLE
Use working-directory keyed concurrency guards; add workspace-scoped PTY channels, typed git failures, file-linking UI and test coverage

### DIFF
--- a/crates/terminal-core/src/models.rs
+++ b/crates/terminal-core/src/models.rs
@@ -132,11 +132,23 @@ impl PaneLayout {
 pub enum RunState {
     Preparing,
     Running,
-    Pausing { reason: PauseReason },
-    WaitingInput { question: String, context: Vec<String> },
-    Completed { exit_code: i32 },
-    Failed { error: String, phase: FailPhase },
-    Cancelled { reason: String },
+    Pausing {
+        reason: PauseReason,
+    },
+    WaitingInput {
+        question: String,
+        context: Vec<String>,
+    },
+    Completed {
+        exit_code: i32,
+    },
+    Failed {
+        error: String,
+        phase: FailPhase,
+    },
+    Cancelled {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -171,16 +183,11 @@ pub enum RunMode {
 ///   does not execute any edit/write/bash tools. The UI surfaces an
 ///   "Approve & execute" button that fires a fresh autonomous run with the
 ///   same prompt. Maps to `--permission-mode plan`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
 pub enum AutonomyLevel {
+    #[default]
     Autonomous,
     ReviewPlan,
-}
-
-impl Default for AutonomyLevel {
-    fn default() -> Self {
-        AutonomyLevel::Autonomous
-    }
 }
 
 // --- Output ---
@@ -605,7 +612,10 @@ mod tests {
         let json = serde_json::to_string(&meta).unwrap();
         let deserialized: WorktreeMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.branch_name, "llm/test");
-        assert_eq!(deserialized.repo_root.as_deref(), Some(std::path::Path::new("/tmp/project")));
+        assert_eq!(
+            deserialized.repo_root.as_deref(),
+            Some(std::path::Path::new("/tmp/project"))
+        );
     }
 
     #[test]

--- a/crates/terminal-daemon/src/claude_runner.rs
+++ b/crates/terminal-daemon/src/claude_runner.rs
@@ -141,8 +141,7 @@ impl ClaudeRunner {
 
         match result {
             Ok(out) if out.status.success() => {
-                let version =
-                    String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
                 Ok(PreflightInfo { version })
             }
             Ok(out) => {
@@ -152,9 +151,14 @@ impl ClaudeRunner {
                         "`{} --version` exited with {}: {}",
                         binary,
                         out.status.code().unwrap_or(-1),
-                        if stderr.is_empty() { "no output".into() } else { stderr }
+                        if stderr.is_empty() {
+                            "no output".into()
+                        } else {
+                            stderr
+                        }
                     ),
-                    suggestion: "verify Claude Code is installed and authenticated: `claude doctor`".into(),
+                    suggestion:
+                        "verify Claude Code is installed and authenticated: `claude doctor`".into(),
                 })
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(PreflightFailure {
@@ -254,12 +258,24 @@ impl ClaudeRunner {
                                     .await;
                             }
                         }
-                        ParseEvent::ToolUse { id, name, input_preview } => {
+                        ParseEvent::ToolUse {
+                            id,
+                            name,
+                            input_preview,
+                        } => {
                             let _ = event_tx_stdout
-                                .send(RunnerEvent::ToolUse { id, name, input_preview })
+                                .send(RunnerEvent::ToolUse {
+                                    id,
+                                    name,
+                                    input_preview,
+                                })
                                 .await;
                         }
-                        ParseEvent::ToolResult { tool_use_id, is_error, preview } => {
+                        ParseEvent::ToolResult {
+                            tool_use_id,
+                            is_error,
+                            preview,
+                        } => {
                             let _ = event_tx_stdout
                                 .send(RunnerEvent::ToolResult {
                                     tool_use_id,
@@ -296,9 +312,7 @@ impl ClaudeRunner {
                             if !success {
                                 let reason = error_text
                                     .unwrap_or_else(|| format!("claude result: {subtype}"));
-                                let _ = event_tx_stdout
-                                    .send(RunnerEvent::StderrLine(reason))
-                                    .await;
+                                let _ = event_tx_stdout.send(RunnerEvent::StderrLine(reason)).await;
                             }
                         }
                         ParseEvent::RawLine(l) => {
@@ -353,7 +367,10 @@ pub struct PreflightFailure {
 
 /// Get the output file path for a given run.
 pub fn output_file_path(data_dir: &Path, run_id: &Uuid) -> PathBuf {
-    data_dir.join("runs").join(run_id.to_string()).join("output.jsonl")
+    data_dir
+        .join("runs")
+        .join(run_id.to_string())
+        .join("output.jsonl")
 }
 
 #[cfg(test)]
@@ -396,8 +413,10 @@ mod tests {
 
     #[tokio::test]
     async fn preflight_reports_missing_binary() {
-        let mut cfg = DaemonConfig::default();
-        cfg.claude_binary = "definitely_not_a_real_binary_xyz_123".into();
+        let cfg = DaemonConfig {
+            claude_binary: "definitely_not_a_real_binary_xyz_123".into(),
+            ..Default::default()
+        };
         let runner = ClaudeRunner::new(cfg);
         let err = runner.preflight().await.unwrap_err();
         assert!(err.reason.contains("not found"));
@@ -406,22 +425,38 @@ mod tests {
 
     #[test]
     fn empty_prompt_rejected() {
-        let mut cfg = DaemonConfig::default();
-        cfg.claude_binary = "echo".into();
+        let cfg = DaemonConfig {
+            claude_binary: "echo".into(),
+            ..Default::default()
+        };
         let runner = ClaudeRunner::new(cfg);
         let err = runner
-            .spawn(Uuid::new_v4(), "", &RunMode::Free, AutonomyLevel::Autonomous, Path::new("/tmp"))
+            .spawn(
+                Uuid::new_v4(),
+                "",
+                &RunMode::Free,
+                AutonomyLevel::Autonomous,
+                Path::new("/tmp"),
+            )
             .unwrap_err();
         assert!(err.to_lowercase().contains("empty"));
     }
 
     #[test]
     fn whitespace_only_prompt_rejected() {
-        let mut cfg = DaemonConfig::default();
-        cfg.claude_binary = "echo".into();
+        let cfg = DaemonConfig {
+            claude_binary: "echo".into(),
+            ..Default::default()
+        };
         let runner = ClaudeRunner::new(cfg);
         let err = runner
-            .spawn(Uuid::new_v4(), "   \n\t  ", &RunMode::Free, AutonomyLevel::Autonomous, Path::new("/tmp"))
+            .spawn(
+                Uuid::new_v4(),
+                "   \n\t  ",
+                &RunMode::Free,
+                AutonomyLevel::Autonomous,
+                Path::new("/tmp"),
+            )
             .unwrap_err();
         assert!(err.to_lowercase().contains("empty"));
     }

--- a/crates/terminal-daemon/src/daemon_context.rs
+++ b/crates/terminal-daemon/src/daemon_context.rs
@@ -23,6 +23,12 @@ impl ClientId {
     }
 }
 
+impl Default for ClientId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Internal state for tracking active runs.
 pub struct ActiveRun {
     #[allow(dead_code)]
@@ -37,7 +43,8 @@ pub struct DaemonContext {
     pub persistence: Arc<Persistence>,
     pub sessions: Arc<Mutex<HashMap<Uuid, Session>>>,
     pub active_runs: Arc<Mutex<HashMap<Uuid, ActiveRun>>>,
-    /// project_root -> run_id (concurrency guard)
+    /// working_dir_path -> run_id (concurrency guard). For git runs this is
+    /// the per-run worktree path; for non-git runs this is the project root.
     pub concurrency: Arc<Mutex<HashMap<PathBuf, Uuid>>>,
     pub runner: Arc<ClaudeRunner>,
     /// Workspaces registry (M1-05)

--- a/crates/terminal-daemon/src/dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatcher.rs
@@ -18,6 +18,15 @@ pub struct Dispatcher {
     pty_manager: Arc<PtyManager>,
 }
 
+fn concurrency_key_for_run(
+    project_root: &std::path::Path,
+    worktree_path: Option<&std::path::Path>,
+) -> PathBuf {
+    worktree_path
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| project_root.to_path_buf())
+}
+
 impl Dispatcher {
     pub fn new(
         config: DaemonConfig,
@@ -28,7 +37,10 @@ impl Dispatcher {
         let pty_manager = Arc::new(
             PtyManager::new(event_tx).with_workspace_channels(context.workspace_channels.clone()),
         );
-        Self { context, pty_manager }
+        Self {
+            context,
+            pty_manager,
+        }
     }
 
     /// Broadcast an event to all connected clients.
@@ -54,7 +66,9 @@ impl Dispatcher {
         let mut channels = self.context.workspace_channels.lock().await;
         for ws in persisted {
             let id = ws.id;
-            channels.entry(id).or_insert_with(|| broadcast::channel(512).0);
+            channels
+                .entry(id)
+                .or_insert_with(|| broadcast::channel(512).0);
             workspaces.insert(id, ws);
         }
         info!("Recovered {} persisted workspace(s)", workspaces.len());
@@ -67,7 +81,12 @@ impl Dispatcher {
     }
 
     /// Handle a command and send response to the requesting client.
-    pub async fn handle(&self, client_id: ClientId, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
+    pub async fn handle(
+        &self,
+        client_id: ClientId,
+        cmd: AppCommand,
+        reply_tx: mpsc::Sender<AppEvent>,
+    ) {
         let _ = client_id; // forwarded to workspace_dispatcher; suppressed elsewhere
         match cmd {
             AppCommand::Auth { .. } => {
@@ -75,7 +94,6 @@ impl Dispatcher {
             }
 
             // --- File viewer (TERMINAL-005) ---
-
             AppCommand::ReadFile { path, max_bytes } => {
                 let limit = max_bytes.unwrap_or(1_048_576u64); // 1 MB default
 
@@ -96,10 +114,7 @@ impl Dispatcher {
                 if let Some(ref root) = project_root {
                     if let Err(e) = crate::safety::validate_path(root, &resolved) {
                         let _ = reply_tx
-                            .send(AppEvent::FileReadError {
-                                path,
-                                error: e,
-                            })
+                            .send(AppEvent::FileReadError { path, error: e })
                             .await;
                         return;
                     }
@@ -141,7 +156,8 @@ impl Dispatcher {
                             // `take` caps reads at read_limit bytes. One extra
                             // byte would be needed to *detect* truncation, but
                             // size_bytes already tells us that for regular files.
-                            if let Err(e) = file.take(read_limit as u64).read_to_end(&mut buf).await {
+                            if let Err(e) = file.take(read_limit as u64).read_to_end(&mut buf).await
+                            {
                                 let _ = reply_tx
                                     .send(AppEvent::FileReadError {
                                         path,
@@ -172,11 +188,8 @@ impl Dispatcher {
                         let (content, truncated) = {
                             let line_count = text.lines().count();
                             if size_bytes > limit || line_count > MAX_LINES {
-                                let truncated_text: String = text
-                                    .lines()
-                                    .take(MAX_LINES)
-                                    .collect::<Vec<_>>()
-                                    .join("\n");
+                                let truncated_text: String =
+                                    text.lines().take(MAX_LINES).collect::<Vec<_>>().join("\n");
                                 (truncated_text + "\n[truncated]", true)
                             } else {
                                 (text, false)
@@ -299,7 +312,11 @@ impl Dispatcher {
                     started_at: session.started_at,
                 };
 
-                self.context.sessions.lock().await.insert(session_id, session);
+                self.context
+                    .sessions
+                    .lock()
+                    .await
+                    .insert(session_id, session);
                 let _ = reply_tx
                     .send(AppEvent::SessionStarted { session: summary })
                     .await;
@@ -316,9 +333,7 @@ impl Dispatcher {
                         warn!("Failed to persist ended session {}: {}", session_id, e);
                     }
 
-                    let _ = reply_tx
-                        .send(AppEvent::SessionEnded { session_id })
-                        .await;
+                    let _ = reply_tx.send(AppEvent::SessionEnded { session_id }).await;
                 } else {
                     let _ = reply_tx
                         .send(AppEvent::Error {
@@ -353,9 +368,15 @@ impl Dispatcher {
                 match sessions.get(&session_id) {
                     Some(_session) => {
                         // Load persisted runs
-                        let persisted_runs = self.context.persistence.list_runs_for_session(session_id)
+                        let persisted_runs = self
+                            .context
+                            .persistence
+                            .list_runs_for_session(session_id)
                             .unwrap_or_else(|e| {
-                                warn!("Failed to load persisted runs for session {}: {}", session_id, e);
+                                warn!(
+                                    "Failed to load persisted runs for session {}: {}",
+                                    session_id, e
+                                );
                                 vec![]
                             });
 
@@ -367,31 +388,42 @@ impl Dispatcher {
 
                         // First, add persisted runs
                         for run in &persisted_runs {
-                            summaries_map.insert(run.id, RunSummary {
-                                id: run.id,
-                                state: run.state.clone(),
-                                prompt_preview: run.prompt.chars().take(100).collect(),
-                                modified_file_count: run.modified_files.len(),
-                                diff_stat: None,
-                                started_at: run.started_at,
-                                ended_at: run.ended_at,
-                                autonomy: run.autonomy,
-                            });
+                            summaries_map.insert(
+                                run.id,
+                                RunSummary {
+                                    id: run.id,
+                                    state: run.state.clone(),
+                                    prompt_preview: run.prompt.chars().take(100).collect(),
+                                    modified_file_count: run.modified_files.len(),
+                                    diff_stat: None,
+                                    started_at: run.started_at,
+                                    ended_at: run.ended_at,
+                                    autonomy: run.autonomy,
+                                },
+                            );
                         }
 
                         // Then, override with active runs (more current state)
                         for active in active_runs.values() {
                             if active.run.session_id == session_id {
-                                summaries_map.insert(active.run.id, RunSummary {
-                                    id: active.run.id,
-                                    state: active.run.state.clone(),
-                                    prompt_preview: active.run.prompt.chars().take(100).collect(),
-                                    modified_file_count: active.run.modified_files.len(),
-                                    diff_stat: None,
-                                    started_at: active.run.started_at,
-                                    ended_at: active.run.ended_at,
-                                    autonomy: active.run.autonomy,
-                                });
+                                summaries_map.insert(
+                                    active.run.id,
+                                    RunSummary {
+                                        id: active.run.id,
+                                        state: active.run.state.clone(),
+                                        prompt_preview: active
+                                            .run
+                                            .prompt
+                                            .chars()
+                                            .take(100)
+                                            .collect(),
+                                        modified_file_count: active.run.modified_files.len(),
+                                        diff_stat: None,
+                                        started_at: active.run.started_at,
+                                        ended_at: active.run.ended_at,
+                                        autonomy: active.run.autonomy,
+                                    },
+                                );
                             }
                         }
 
@@ -419,7 +451,13 @@ impl Dispatcher {
             AppCommand::GetRunStatus { run_id } => {
                 // Read the state, then release the lock before awaiting the
                 // reply send — don't hold active_runs across a channel await.
-                let state = self.context.active_runs.lock().await.get(&run_id).map(|a| a.run.state.clone());
+                let state = self
+                    .context
+                    .active_runs
+                    .lock()
+                    .await
+                    .get(&run_id)
+                    .map(|a| a.run.state.clone());
                 match state {
                     Some(new_state) => {
                         let _ = reply_tx
@@ -444,7 +482,16 @@ impl Dispatcher {
                 skip_dirty_check,
                 autonomy,
             } => {
-                self.do_start_run(client_id, session_id, prompt, mode, autonomy, skip_dirty_check, reply_tx).await;
+                self.do_start_run(
+                    client_id,
+                    session_id,
+                    prompt,
+                    mode,
+                    autonomy,
+                    skip_dirty_check,
+                    reply_tx,
+                )
+                .await;
             }
 
             AppCommand::CancelRun { run_id, reason } => {
@@ -452,7 +499,13 @@ impl Dispatcher {
                 // cancel_tx has capacity 1 and a blocked send would hold the
                 // active_runs lock, starving the supervisor that needs it to
                 // remove the entry on completion.
-                let sender = self.context.active_runs.lock().await.get(&run_id).map(|r| r.cancel_tx.clone());
+                let sender = self
+                    .context
+                    .active_runs
+                    .lock()
+                    .await
+                    .get(&run_id)
+                    .map(|r| r.cancel_tx.clone());
                 match sender {
                     Some(tx) => {
                         let _ = tx.send(reason).await;
@@ -528,8 +581,12 @@ impl Dispatcher {
                         };
 
                         let stat = match crate::git_engine::diff_stat(
-                            &meta.worktree_path, &meta.base_head, &wt_head
-                        ).await {
+                            &meta.worktree_path,
+                            &meta.base_head,
+                            &wt_head,
+                        )
+                        .await
+                        {
                             Ok(s) => s,
                             Err(e) => {
                                 let _ = reply_tx
@@ -543,8 +600,12 @@ impl Dispatcher {
                         };
 
                         let diff = match crate::git_engine::diff_full(
-                            &meta.worktree_path, &meta.base_head, &wt_head
-                        ).await {
+                            &meta.worktree_path,
+                            &meta.base_head,
+                            &wt_head,
+                        )
+                        .await
+                        {
                             Ok(d) => d,
                             Err(e) => {
                                 let _ = reply_tx
@@ -558,11 +619,7 @@ impl Dispatcher {
                         };
 
                         let _ = reply_tx
-                            .send(AppEvent::RunDiff {
-                                run_id,
-                                stat,
-                                diff,
-                            })
+                            .send(AppEvent::RunDiff { run_id, stat, diff })
                             .await;
                     }
                     Err(e) => {
@@ -608,26 +665,34 @@ impl Dispatcher {
 
                 // Remove worktree if it exists
                 if meta.worktree_path.exists() {
-                    if let Err(e) = crate::git_engine::worktree_remove(&project_root, &meta.worktree_path).await {
+                    if let Err(e) =
+                        crate::git_engine::worktree_remove(&project_root, &meta.worktree_path).await
+                    {
                         warn!("Failed to remove worktree for run {}: {}", run_id, e);
                     }
                 }
 
                 // Delete branch (force)
-                if let Err(e) = crate::git_engine::branch_delete(&project_root, &meta.branch_name, true).await {
-                    warn!("Failed to delete branch {} for run {}: {}", meta.branch_name, run_id, e);
+                if let Err(e) =
+                    crate::git_engine::branch_delete(&project_root, &meta.branch_name, true).await
+                {
+                    warn!(
+                        "Failed to delete branch {} for run {}: {}",
+                        meta.branch_name, run_id, e
+                    );
                 }
 
                 // Delete worktree metadata
                 if let Err(e) = self.context.persistence.delete_worktree_meta(run_id) {
-                    warn!("Failed to delete worktree metadata for run {}: {}", run_id, e);
+                    warn!(
+                        "Failed to delete worktree metadata for run {}: {}",
+                        run_id, e
+                    );
                 }
 
                 // Broadcast RunReverted
                 self.broadcast(&AppEvent::RunReverted { run_id });
-                let _ = reply_tx
-                    .send(AppEvent::RunReverted { run_id })
-                    .await;
+                let _ = reply_tx.send(AppEvent::RunReverted { run_id }).await;
             }
 
             AppCommand::MergeRun { run_id } => {
@@ -662,8 +727,13 @@ impl Dispatcher {
 
                 // Remove worktree before merging (can't merge into a checked-out branch)
                 if meta.worktree_path.exists() {
-                    if let Err(e) = crate::git_engine::worktree_remove(&project_root, &meta.worktree_path).await {
-                        warn!("Failed to remove worktree before merge for run {}: {}", run_id, e);
+                    if let Err(e) =
+                        crate::git_engine::worktree_remove(&project_root, &meta.worktree_path).await
+                    {
+                        warn!(
+                            "Failed to remove worktree before merge for run {}: {}",
+                            run_id, e
+                        );
                     }
                 }
 
@@ -688,11 +758,20 @@ impl Dispatcher {
                     }
                     Ok(merge_result) => {
                         // Success: clean up branch and metadata
-                        if let Err(e) = crate::git_engine::branch_delete(&project_root, &meta.branch_name, true).await {
-                            warn!("Failed to delete branch after merge for run {}: {}", run_id, e);
+                        if let Err(e) =
+                            crate::git_engine::branch_delete(&project_root, &meta.branch_name, true)
+                                .await
+                        {
+                            warn!(
+                                "Failed to delete branch after merge for run {}: {}",
+                                run_id, e
+                            );
                         }
                         if let Err(e) = self.context.persistence.delete_worktree_meta(run_id) {
-                            warn!("Failed to delete worktree metadata after merge for run {}: {}", run_id, e);
+                            warn!(
+                                "Failed to delete worktree metadata after merge for run {}: {}",
+                                run_id, e
+                            );
                         }
 
                         self.broadcast(&AppEvent::RunMerged {
@@ -718,7 +797,6 @@ impl Dispatcher {
             }
 
             // --- Stash operations (Phase 2.1) ---
-
             AppCommand::StashAndRun {
                 session_id,
                 prompt,
@@ -755,7 +833,16 @@ impl Dispatcher {
 
                 // Stash succeeded -- proceed with start run, skipping dirty check.
                 // Stash-and-run flows default to Autonomous (legacy behaviour).
-                self.do_start_run(client_id, session_id, prompt, mode, AutonomyLevel::default(), true, reply_tx).await;
+                self.do_start_run(
+                    client_id,
+                    session_id,
+                    prompt,
+                    mode,
+                    AutonomyLevel::default(),
+                    true,
+                    reply_tx,
+                )
+                .await;
             }
 
             AppCommand::ListStashes => {
@@ -774,9 +861,7 @@ impl Dispatcher {
 
                 match crate::git_engine::stash_list(&project_root).await {
                     Ok(stashes) => {
-                        let _ = reply_tx
-                            .send(AppEvent::StashList { stashes })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::StashList { stashes }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
@@ -820,7 +905,10 @@ impl Dispatcher {
                 }
             }
 
-            AppCommand::GetStashDiff { stash_index, file_path } => {
+            AppCommand::GetStashDiff {
+                stash_index,
+                file_path,
+            } => {
                 let project_root = match self.find_active_project_root().await {
                     Some(pr) => pr,
                     None => {
@@ -880,9 +968,7 @@ impl Dispatcher {
 
                 match crate::git_engine::working_dir_status(&project_root).await {
                     Ok(status) => {
-                        let _ = reply_tx
-                            .send(AppEvent::DirtyState { status })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::DirtyState { status }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
@@ -896,28 +982,27 @@ impl Dispatcher {
             }
 
             // --- Sidebar commands (Phase 3) ---
-
             AppCommand::ListDirectory { path } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 // Keep the listing confined to the project root. Without
                 // validation, an absolute path or one with `..` components
                 // would let a client enumerate any directory on the host
                 // filesystem.
-                let full_path = match crate::safety::validate_path(
-                    &root,
-                    std::path::Path::new(&path),
-                ) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        let _ = reply_tx
-                            .send(AppEvent::Error {
-                                code: "LIST_DIR_FAILED".into(),
-                                message: e,
-                            })
-                            .await;
-                        return;
-                    }
-                };
+                let full_path =
+                    match crate::safety::validate_path(&root, std::path::Path::new(&path)) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            let _ = reply_tx
+                                .send(AppEvent::Error {
+                                    code: "LIST_DIR_FAILED".into(),
+                                    message: e,
+                                })
+                                .await;
+                            return;
+                        }
+                    };
                 match crate::git_engine::list_directory(&full_path).await {
                     Ok(entries) => {
                         let _ = reply_tx
@@ -936,7 +1021,9 @@ impl Dispatcher {
             }
 
             AppCommand::GetChangedFiles { mode, run_id } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 let result: std::result::Result<Vec<FileChange>, String> = if mode == "working" {
                     match crate::git_engine::working_dir_status(&root).await {
                         Ok(s) => {
@@ -995,7 +1082,9 @@ impl Dispatcher {
                 mode,
                 run_id,
             } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 let result: std::result::Result<String, String> = if mode == "working" {
                     crate::git_engine::working_dir_file_diff(&root, &file_path)
                         .await
@@ -1033,12 +1122,12 @@ impl Dispatcher {
             }
 
             AppCommand::GetRepoStatus => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::repo_status_snapshot(&root).await {
                     Ok(status) => {
-                        let _ = reply_tx
-                            .send(AppEvent::RepoStatusResult { status })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::RepoStatusResult { status }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
@@ -1052,7 +1141,9 @@ impl Dispatcher {
             }
 
             AppCommand::GetCommitHistory { limit } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::commit_history(&root, limit).await {
                     Ok(commits) => {
                         let _ = reply_tx
@@ -1071,7 +1162,9 @@ impl Dispatcher {
             }
 
             AppCommand::StageFile { path } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 if let Err(e) = crate::git_engine::stage_file(&root, &path).await {
                     let _ = reply_tx
                         .send(AppEvent::Error {
@@ -1080,35 +1173,33 @@ impl Dispatcher {
                         })
                         .await;
                 } else if let Ok(status) = crate::git_engine::repo_status_snapshot(&root).await {
-                    let _ = reply_tx
-                        .send(AppEvent::RepoStatusResult { status })
-                        .await;
+                    let _ = reply_tx.send(AppEvent::RepoStatusResult { status }).await;
                 }
             }
 
             AppCommand::UnstageFile { path } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 if let Err(e) = crate::git_engine::unstage_file(&root, &path).await {
                     let _ = reply_tx
                         .send(AppEvent::Error {
-                                code: "UNSTAGE_FAILED".into(),
-                                message: e.to_string(),
+                            code: "UNSTAGE_FAILED".into(),
+                            message: e.to_string(),
                         })
                         .await;
                 } else if let Ok(status) = crate::git_engine::repo_status_snapshot(&root).await {
-                    let _ = reply_tx
-                        .send(AppEvent::RepoStatusResult { status })
-                        .await;
+                    let _ = reply_tx.send(AppEvent::RepoStatusResult { status }).await;
                 }
             }
 
             AppCommand::CreateCommit { message } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::create_commit(&root, &message).await {
                     Ok(hash) => {
-                        let _ = reply_tx
-                            .send(AppEvent::CommitCreated { hash })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::CommitCreated { hash }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
@@ -1122,7 +1213,9 @@ impl Dispatcher {
             }
 
             AppCommand::ListBranches => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::list_branches(&root).await {
                     Ok((branches, current)) => {
                         let _ = reply_tx
@@ -1141,12 +1234,12 @@ impl Dispatcher {
             }
 
             AppCommand::CheckoutBranch { name } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::checkout_branch(&root, &name).await {
                     Ok(()) => {
-                        let _ = reply_tx
-                            .send(AppEvent::BranchChanged { name })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::BranchChanged { name }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
@@ -1160,12 +1253,12 @@ impl Dispatcher {
             }
 
             AppCommand::CreateBranch { name, from } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::create_branch(&root, &name, from.as_deref()).await {
                     Ok(()) => {
-                        let _ = reply_tx
-                            .send(AppEvent::BranchChanged { name })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::BranchChanged { name }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
@@ -1190,9 +1283,16 @@ impl Dispatcher {
             }
 
             // --- PTY commands (M4-01) ---
-            AppCommand::CreateTerminalSession { workspace_id, shell, cwd, env, ssh } => {
+            AppCommand::CreateTerminalSession {
+                workspace_id,
+                shell,
+                cwd,
+                env,
+                ssh,
+            } => {
                 let pane_id = format!("terminal-{}", workspace_id);
-                let result = self.pty_manager
+                let result = self
+                    .pty_manager
                     .create_session(workspace_id, pane_id, shell, cwd, env, ssh)
                     .await;
                 match result {
@@ -1230,29 +1330,41 @@ impl Dispatcher {
                 }
             }
 
-            AppCommand::ResizeTerminal { session_id, cols, rows } => {
-                match self.pty_manager.resize(session_id, cols, rows).await {
-                    Ok(()) => {}
-                    Err(e) => {
-                        let _ = reply_tx
-                            .send(AppEvent::Error {
-                                code: "RESIZE_FAILED".into(),
-                                message: e,
-                            })
-                            .await;
-                    }
+            AppCommand::ResizeTerminal {
+                session_id,
+                cols,
+                rows,
+            } => match self.pty_manager.resize(session_id, cols, rows).await {
+                Ok(()) => {}
+                Err(e) => {
+                    let _ = reply_tx
+                        .send(AppEvent::Error {
+                            code: "RESIZE_FAILED".into(),
+                            message: e,
+                        })
+                        .await;
                 }
-            }
+            },
 
             AppCommand::ListTerminalSessions { workspace_id } => {
                 let sessions = self.pty_manager.list_sessions(workspace_id).await;
                 let _ = reply_tx
-                    .send(AppEvent::TerminalSessionList { workspace_id, sessions })
+                    .send(AppEvent::TerminalSessionList {
+                        workspace_id,
+                        sessions,
+                    })
                     .await;
             }
 
-            AppCommand::RestoreTerminalSession { previous_session_id, workspace_id } => {
-                let meta = match self.context.persistence.load_terminal_session(previous_session_id) {
+            AppCommand::RestoreTerminalSession {
+                previous_session_id,
+                workspace_id,
+            } => {
+                let meta = match self
+                    .context
+                    .persistence
+                    .load_terminal_session(previous_session_id)
+                {
                     Ok(m) => m,
                     Err(crate::persistence::PersistenceError::NotFound(_)) => {
                         let _ = reply_tx
@@ -1276,12 +1388,23 @@ impl Dispatcher {
                 let shell = meta.shell_path.to_string_lossy().to_string();
                 let cwd = meta.cwd.clone();
                 let pane_id = format!("terminal-restored-{}", workspace_id);
-                match self.pty_manager
-                    .create_session(workspace_id, pane_id, Some(shell.clone()), Some(cwd.clone()), None, None)
+                match self
+                    .pty_manager
+                    .create_session(
+                        workspace_id,
+                        pane_id,
+                        Some(shell.clone()),
+                        Some(cwd.clone()),
+                        None,
+                        None,
+                    )
                     .await
                 {
                     Ok(new_session_id) => {
-                        let _ = self.context.persistence.delete_terminal_session(previous_session_id);
+                        let _ = self
+                            .context
+                            .persistence
+                            .delete_terminal_session(previous_session_id);
                         let _ = reply_tx
                             .send(AppEvent::TerminalSessionRestored {
                                 previous_session_id,
@@ -1303,7 +1426,11 @@ impl Dispatcher {
             }
 
             AppCommand::ListRestoredTerminalSessions { workspace_id } => {
-                match self.context.persistence.list_terminal_sessions(workspace_id) {
+                match self
+                    .context
+                    .persistence
+                    .list_terminal_sessions(workspace_id)
+                {
                     Ok(sessions) => {
                         let _ = reply_tx
                             .send(AppEvent::RestorableTerminalSessions {
@@ -1324,48 +1451,69 @@ impl Dispatcher {
             }
 
             // --- Stash mutations (M4) ---
-
             AppCommand::PopStash { index } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::stash_pop(&root, index).await {
                     Ok(had_conflicts) => {
-                        let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
+                        let _ = reply_tx
+                            .send(AppEvent::StashApplied {
+                                index,
+                                had_conflicts,
+                            })
+                            .await;
                     }
                     Err(e) => {
-                        let _ = reply_tx.send(AppEvent::Error {
-                            code: "STASH_FAILED".into(),
-                            message: e.to_string(),
-                        }).await;
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "STASH_FAILED".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
 
             AppCommand::ApplyStash { index } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::stash_apply(&root, index).await {
                     Ok(had_conflicts) => {
-                        let _ = reply_tx.send(AppEvent::StashApplied { index, had_conflicts }).await;
+                        let _ = reply_tx
+                            .send(AppEvent::StashApplied {
+                                index,
+                                had_conflicts,
+                            })
+                            .await;
                     }
                     Err(e) => {
-                        let _ = reply_tx.send(AppEvent::Error {
-                            code: "STASH_FAILED".into(),
-                            message: e.to_string(),
-                        }).await;
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "STASH_FAILED".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
 
             AppCommand::DropStash { index } => {
-                let Some(root) = self.active_root_or_err(&reply_tx).await else { return; };
+                let Some(root) = self.active_root_or_err(&reply_tx).await else {
+                    return;
+                };
                 match crate::git_engine::stash_drop(&root, index).await {
                     Ok(()) => {
                         let _ = reply_tx.send(AppEvent::StashDropped { index }).await;
                     }
                     Err(e) => {
-                        let _ = reply_tx.send(AppEvent::Error {
-                            code: "STASH_FAILED".into(),
-                            message: e.to_string(),
-                        }).await;
+                        let _ = reply_tx
+                            .send(AppEvent::Error {
+                                code: "STASH_FAILED".into(),
+                                message: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }
@@ -1376,15 +1524,15 @@ impl Dispatcher {
             | AppCommand::FetchRemote { .. }
             | AppCommand::GetMergeConflicts
             | AppCommand::ResolveConflict { .. } => {
-                let dispatcher = crate::dispatchers::git_dispatcher::GitDispatcher::new(
-                    self.context.clone(),
-                );
+                let dispatcher =
+                    crate::dispatchers::git_dispatcher::GitDispatcher::new(self.context.clone());
                 dispatcher.handle(cmd, reply_tx).await;
             }
         }
     }
 
     /// Core StartRun logic, shared by both `StartRun` and `StashAndRun` commands.
+    #[allow(clippy::too_many_arguments)]
     async fn do_start_run(
         &self,
         client_id: ClientId,
@@ -1460,34 +1608,9 @@ impl Dispatcher {
 
         // RAII concurrency guard — dropped on early return, `forget()` once
         // the supervisor task takes ownership of cleanup on successful spawn.
-        let mut concurrency_guard: Option<ConcurrencyGuard> = None;
+        let mut concurrency_guard: Option<ConcurrencyGuard>;
 
         if is_git {
-            // Concurrency guard (see crate::guards): removes the entry on
-            // any early return below without manual cleanup.
-            let guard = match ConcurrencyGuard::acquire(
-                self.context.concurrency.clone(),
-                project_root.clone(),
-                run_id,
-            )
-            .await
-            {
-                Some(g) => g,
-                None => {
-                    let _ = reply_tx
-                        .send(AppEvent::Error {
-                            code: "REPO_BUSY".into(),
-                            message: format!(
-                                "Repository {} already has an active run",
-                                project_root.display()
-                            ),
-                        })
-                        .await;
-                    return;
-                }
-            };
-            concurrency_guard = Some(guard);
-
             // Guard repo state
             if let Err(e) = crate::git_engine::guard_repo_state(&project_root).await {
                 let _ = reply_tx
@@ -1566,7 +1689,9 @@ impl Dispatcher {
             }
 
             // Create worktree
-            if let Err(e) = crate::git_engine::worktree_add(&project_root, &wt_path, &branch_name).await {
+            if let Err(e) =
+                crate::git_engine::worktree_add(&project_root, &wt_path, &branch_name).await
+            {
                 let _ = reply_tx
                     .send(AppEvent::Error {
                         code: "GIT_ERROR".into(),
@@ -1592,6 +1717,32 @@ impl Dispatcher {
             actual_working_dir = wt_path.clone();
             worktree_path = Some(wt_path);
         }
+        let concurrency_key = concurrency_key_for_run(&project_root, worktree_path.as_deref());
+
+        // Concurrency guard (see crate::guards): removes the entry on
+        // any early return below without manual cleanup.
+        let guard = match ConcurrencyGuard::acquire(
+            self.context.concurrency.clone(),
+            concurrency_key.clone(),
+            run_id,
+        )
+        .await
+        {
+            Some(g) => g,
+            None => {
+                let _ = reply_tx
+                    .send(AppEvent::Error {
+                        code: "WORKING_DIR_BUSY".into(),
+                        message: format!(
+                            "Working directory {} already has an active run",
+                            concurrency_key.display()
+                        ),
+                    })
+                    .await;
+                return;
+            }
+        };
+        concurrency_guard = Some(guard);
 
         let run = Run {
             id: run_id,
@@ -1630,7 +1781,8 @@ impl Dispatcher {
                 // EndSession). Clean up what we already created.
                 if let Some(ref wt_path) = worktree_path {
                     let _ = crate::git_engine::worktree_remove(&project_root, wt_path).await;
-                    let _ = crate::git_engine::branch_delete(&project_root, &branch_name, true).await;
+                    let _ =
+                        crate::git_engine::branch_delete(&project_root, &branch_name, true).await;
                 }
                 let _ = reply_tx
                     .send(AppEvent::Error {
@@ -1656,7 +1808,11 @@ impl Dispatcher {
         // Spawn claude process in actual_working_dir (worktree if git).
         // Ownership of the concurrency entry transfers to the supervisor task
         // on success; `forget()` prevents the guard from clearing it on drop.
-        match self.context.runner.spawn(run_id, &prompt, &mode, autonomy, &actual_working_dir) {
+        match self
+            .context
+            .runner
+            .spawn(run_id, &prompt, &mode, autonomy, &actual_working_dir)
+        {
             Ok((mut event_rx, mut child)) => {
                 if let Some(g) = concurrency_guard.take() {
                     g.forget();
@@ -1667,7 +1823,11 @@ impl Dispatcher {
                     run: run.clone(),
                     cancel_tx,
                 };
-                self.context.active_runs.lock().await.insert(run_id, active_run);
+                self.context
+                    .active_runs
+                    .lock()
+                    .await
+                    .insert(run_id, active_run);
 
                 // Transition to Running
                 self.broadcast(&AppEvent::RunStateChanged {
@@ -1684,6 +1844,7 @@ impl Dispatcher {
                 let persistence = self.context.persistence.clone();
                 let concurrency = self.context.concurrency.clone();
                 let project_root_clone = project_root.clone();
+                let concurrency_key_clone = concurrency_key.clone();
                 let base_head_clone = base_head.clone();
                 let branch_name_clone = branch_name.clone();
                 let worktree_path_clone = worktree_path.clone();
@@ -1749,8 +1910,7 @@ impl Dispatcher {
                         }
                     };
 
-                    let timeout =
-                        tokio::time::sleep(std::time::Duration::from_secs(timeout_secs));
+                    let timeout = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs));
                     tokio::pin!(timeout);
 
                     loop {
@@ -2045,9 +2205,7 @@ impl Dispatcher {
                         session.active_run = None;
                     }
                     // Remove from concurrency registry
-                    if is_git_run {
-                        concurrency.lock().await.remove(&project_root_clone);
-                    }
+                    concurrency.lock().await.remove(&concurrency_key_clone);
                     info!("Run {} finished", run_id);
                 });
 
@@ -2068,10 +2226,15 @@ impl Dispatcher {
                 // `concurrency_guard` drops at end of scope.
                 if is_git {
                     if let Some(ref wt_path) = worktree_path {
-                        if let Err(e) = crate::git_engine::worktree_remove(&project_root, wt_path).await {
+                        if let Err(e) =
+                            crate::git_engine::worktree_remove(&project_root, wt_path).await
+                        {
                             warn!("Failed to cleanup worktree on spawn failure: {}", e);
                         }
-                        if let Err(e) = crate::git_engine::branch_delete(&project_root, &branch_name, true).await {
+                        if let Err(e) =
+                            crate::git_engine::branch_delete(&project_root, &branch_name, true)
+                                .await
+                        {
                             warn!("Failed to cleanup branch on spawn failure: {}", e);
                         }
                     }
@@ -2138,7 +2301,8 @@ impl Dispatcher {
                 let _ = reply_tx
                     .send(AppEvent::Error {
                         code: "NO_ACTIVE_SESSION".into(),
-                        message: "No active session — start a session before calling this command".into(),
+                        message: "No active session — start a session before calling this command"
+                            .into(),
                     })
                     .await;
                 None
@@ -2180,7 +2344,7 @@ impl Dispatcher {
 }
 
 /// Detect a display language name from a file path's extension.
-fn detect_language(path: &PathBuf) -> String {
+fn detect_language(path: &std::path::Path) -> String {
     path.extension()
         .and_then(|e| e.to_str())
         .map(|ext| match ext {
@@ -2203,6 +2367,7 @@ fn detect_language(path: &PathBuf) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::concurrency_key_for_run;
     use crate::safety::validate_path;
     use std::path::PathBuf;
 
@@ -2236,5 +2401,20 @@ mod tests {
         let result = validate_path(&root, &tricky);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), root.join("Cargo.toml"));
+    }
+
+    #[test]
+    fn concurrency_key_uses_project_root_when_no_worktree() {
+        let root = PathBuf::from("/repo");
+        let key = concurrency_key_for_run(&root, None);
+        assert_eq!(key, root);
+    }
+
+    #[test]
+    fn concurrency_key_prefers_worktree_when_present() {
+        let root = PathBuf::from("/repo");
+        let wt = PathBuf::from("/repo/.terminal-worktrees/abc12345");
+        let key = concurrency_key_for_run(&root, Some(&wt));
+        assert_eq!(key, wt);
     }
 }

--- a/crates/terminal-daemon/src/dispatchers/git_dispatcher.rs
+++ b/crates/terminal-daemon/src/dispatchers/git_dispatcher.rs
@@ -1,8 +1,9 @@
 // Git domain dispatcher — extended git operations (M1-04, M5-03, M5-04, M5-05)
 
 use crate::daemon_context::DaemonContext;
+use std::path::PathBuf;
 use std::sync::Arc;
-use terminal_core::protocol::v1::{AppEvent, AppCommand};
+use terminal_core::protocol::v1::{AppCommand, AppEvent};
 use tokio::sync::mpsc;
 use tracing::warn;
 
@@ -15,26 +16,31 @@ impl GitDispatcher {
         Self { ctx }
     }
 
-    pub async fn handle(&self, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
-        // Every handler needs an active project root. Resolve once so the
-        // failure path is uniform: emit NO_ACTIVE_SESSION and return rather
-        // than silently dropping the command (which leaves the client
-        // waiting indefinitely for a reply event).
-        let root = match self.ctx.find_active_project_root().await {
-            Some(r) => r,
+    async fn require_project_root(
+        &self,
+        operation: &str,
+        reply_tx: &mpsc::Sender<AppEvent>,
+    ) -> Option<PathBuf> {
+        match self.ctx.find_active_project_root().await {
+            Some(root) => Some(root),
             None => {
                 let _ = reply_tx
-                    .send(AppEvent::Error {
-                        code: "NO_ACTIVE_SESSION".into(),
-                        message: "No active session to resolve project root".into(),
+                    .send(AppEvent::GitOperationFailed {
+                        operation: operation.into(),
+                        reason: "no active session".into(),
                     })
                     .await;
-                return;
+                None
             }
-        };
+        }
+    }
 
+    pub async fn handle(&self, cmd: AppCommand, reply_tx: mpsc::Sender<AppEvent>) {
         match cmd {
             AppCommand::PushBranch { remote, branch } => {
+                let Some(root) = self.require_project_root("push", &reply_tx).await else {
+                    return;
+                };
                 let remote = remote.unwrap_or_else(|| "origin".into());
                 let branch_name = branch.unwrap_or_else(|| "HEAD".into());
                 match crate::git_engine::push_branch(&root, &remote, &branch_name).await {
@@ -58,6 +64,9 @@ impl GitDispatcher {
             }
 
             AppCommand::PullBranch { remote, branch } => {
+                let Some(root) = self.require_project_root("pull", &reply_tx).await else {
+                    return;
+                };
                 let remote = remote.unwrap_or_else(|| "origin".into());
                 match crate::git_engine::pull_branch(&root, &remote, branch.as_deref()).await {
                     Ok(commits_applied) => {
@@ -81,12 +90,13 @@ impl GitDispatcher {
             }
 
             AppCommand::FetchRemote { remote } => {
+                let Some(root) = self.require_project_root("fetch", &reply_tx).await else {
+                    return;
+                };
                 let remote = remote.unwrap_or_else(|| "origin".into());
                 match crate::git_engine::fetch_remote(&root, &remote).await {
                     Ok(()) => {
-                        let _ = reply_tx
-                            .send(AppEvent::FetchCompleted { remote })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::FetchCompleted { remote }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
@@ -100,24 +110,37 @@ impl GitDispatcher {
             }
 
             AppCommand::GetMergeConflicts => {
+                let Some(root) = self
+                    .require_project_root("get_merge_conflicts", &reply_tx)
+                    .await
+                else {
+                    return;
+                };
                 match crate::git_engine::list_merge_conflicts(&root).await {
                     Ok(files) => {
-                        let _ = reply_tx
-                            .send(AppEvent::MergeConflicts { files })
-                            .await;
+                        let _ = reply_tx.send(AppEvent::MergeConflicts { files }).await;
                     }
                     Err(e) => {
                         let _ = reply_tx
-                            .send(AppEvent::Error {
-                                code: "MERGE_CONFLICTS_FAILED".into(),
-                                message: e.to_string(),
+                            .send(AppEvent::GitOperationFailed {
+                                operation: "get_merge_conflicts".into(),
+                                reason: e.to_string(),
                             })
                             .await;
                     }
                 }
             }
 
-            AppCommand::ResolveConflict { file_path, resolution } => {
+            AppCommand::ResolveConflict {
+                file_path,
+                resolution,
+            } => {
+                let Some(root) = self
+                    .require_project_root("resolve_conflict", &reply_tx)
+                    .await
+                else {
+                    return;
+                };
                 match crate::git_engine::resolve_conflict(&root, &file_path, &resolution).await {
                     Ok(()) => {
                         let _ = reply_tx
@@ -126,9 +149,9 @@ impl GitDispatcher {
                     }
                     Err(e) => {
                         let _ = reply_tx
-                            .send(AppEvent::Error {
-                                code: "RESOLVE_CONFLICT_FAILED".into(),
-                                message: e.to_string(),
+                            .send(AppEvent::GitOperationFailed {
+                                operation: "resolve_conflict".into(),
+                                reason: e.to_string(),
                             })
                             .await;
                     }
@@ -138,6 +161,71 @@ impl GitDispatcher {
             _ => {
                 warn!("GitDispatcher received unexpected command");
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use terminal_core::config::DaemonConfig;
+    use terminal_core::protocol::v1::ConflictResolution;
+    use tokio::sync::broadcast;
+
+    fn make_dispatcher(tmp: &TempDir) -> GitDispatcher {
+        let cfg = DaemonConfig {
+            data_dir: tmp.path().to_path_buf(),
+            ..Default::default()
+        };
+        let (event_tx, _) = broadcast::channel::<String>(8);
+        let persistence =
+            Arc::new(crate::persistence::Persistence::new(tmp.path().to_path_buf()).unwrap());
+        let ctx = Arc::new(DaemonContext::new(cfg, event_tx, persistence));
+        GitDispatcher::new(ctx)
+    }
+
+    #[tokio::test]
+    async fn get_merge_conflicts_without_active_session_returns_typed_failure() {
+        let tmp = TempDir::new().unwrap();
+        let dispatcher = make_dispatcher(&tmp);
+        let (tx, mut rx) = mpsc::channel(4);
+
+        dispatcher.handle(AppCommand::GetMergeConflicts, tx).await;
+
+        let event = rx.recv().await.expect("expected one event");
+        match event {
+            AppEvent::GitOperationFailed { operation, reason } => {
+                assert_eq!(operation, "get_merge_conflicts");
+                assert_eq!(reason, "no active session");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_without_active_session_returns_typed_failure() {
+        let tmp = TempDir::new().unwrap();
+        let dispatcher = make_dispatcher(&tmp);
+        let (tx, mut rx) = mpsc::channel(4);
+
+        dispatcher
+            .handle(
+                AppCommand::ResolveConflict {
+                    file_path: PathBuf::from("foo.rs"),
+                    resolution: ConflictResolution::TakeOurs,
+                },
+                tx,
+            )
+            .await;
+
+        let event = rx.recv().await.expect("expected one event");
+        match event {
+            AppEvent::GitOperationFailed { operation, reason } => {
+                assert_eq!(operation, "resolve_conflict");
+                assert_eq!(reason, "no active session");
+            }
+            other => panic!("unexpected event: {other:?}"),
         }
     }
 }

--- a/crates/terminal-daemon/src/guards.rs
+++ b/crates/terminal-daemon/src/guards.rs
@@ -1,7 +1,7 @@
 //! RAII guards for daemon-wide concurrency maps (issue #103, Minor3b).
 //!
 //! `do_start_run` registers the run in two shared maps (concurrency by
-//! project root, active runs by session uuid) and used to remove entries by
+//! actual working directory path, active runs by session uuid) and used to remove entries by
 //! hand on every early-return path. That is fragile — missing a cleanup
 //! site leaks the entry forever and permanently blocks the repo.
 //!
@@ -85,7 +85,7 @@ where
     }
 }
 
-/// Guard for the per-project-root concurrency map
+/// Guard for the per-working-directory concurrency map
 /// (`DaemonContext::concurrency`).
 pub type ConcurrencyGuard = MapKeyGuard<PathBuf, Uuid>;
 

--- a/crates/terminal-daemon/src/persistence.rs
+++ b/crates/terminal-daemon/src/persistence.rs
@@ -66,9 +66,8 @@ impl Persistence {
         }
         #[cfg(unix)]
         if let Some(dir) = path.parent() {
-            if let Ok(dir_file) = fs::File::open(dir) {
-                let _ = dir_file.sync_all();
-            }
+            let dir_file = fs::File::open(dir)?;
+            dir_file.sync_all()?;
         }
         Ok(())
     }
@@ -747,6 +746,24 @@ mod tests {
                 name_str
             );
         }
+    }
+
+    #[test]
+    fn test_atomic_write_persists_non_empty_json() {
+        let dir = tempdir().unwrap();
+        let p = Persistence::new(dir.path().to_path_buf()).unwrap();
+
+        let session = make_session();
+        p.save_session(&session).unwrap();
+
+        let session_path = dir.path().join("sessions").join(format!("{}.json", session.id));
+        let bytes = fs::read(&session_path).unwrap();
+        assert!(
+            !bytes.is_empty(),
+            "session file should never be empty after atomic_write"
+        );
+        let loaded: Session = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(loaded.id, session.id);
     }
 
     #[test]

--- a/crates/terminal-daemon/src/pty/manager.rs
+++ b/crates/terminal-daemon/src/pty/manager.rs
@@ -3,6 +3,7 @@
 // Supports interactive programs (vim, htop, less), signal delivery (Ctrl+C),
 // and terminal resize via TIOCSWINSZ.
 
+use crate::safety::broadcast_event;
 use std::collections::HashMap;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::path::PathBuf;
@@ -14,7 +15,8 @@ use tokio::process::Command;
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tracing::{info, warn};
 use uuid::Uuid;
-use crate::safety::broadcast_event;
+
+type WorkspaceChannels = Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>;
 
 /// A live PTY session.
 pub struct PtySession {
@@ -32,8 +34,7 @@ pub struct PtyManager {
     event_tx: broadcast::Sender<String>,
     /// Shared workspace-scoped broadcast channels (M5c, issue #101). Kept as
     /// an `Option` so tests that don't wire this can still run.
-    workspace_channels:
-        Option<Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>>,
+    workspace_channels: Option<WorkspaceChannels>,
 }
 
 impl PtyManager {
@@ -48,10 +49,7 @@ impl PtyManager {
     /// Attach the shared workspace broadcast channel map. When set, terminal
     /// events route to the owning workspace only, with fallback to the global
     /// channel if the workspace has no subscribers.
-    pub fn with_workspace_channels(
-        mut self,
-        channels: Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>,
-    ) -> Self {
+    pub fn with_workspace_channels(mut self, channels: WorkspaceChannels) -> Self {
         self.workspace_channels = Some(channels);
         self
     }
@@ -68,7 +66,7 @@ impl PtyManager {
 
     async fn emit_via(
         global: &broadcast::Sender<String>,
-        channels: Option<&Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>>,
+        channels: Option<&WorkspaceChannels>,
         workspace_id: Uuid,
         event: &AppEvent,
     ) {
@@ -153,13 +151,12 @@ impl PtyManager {
             (path, vec!["-i".to_string()], false, None)
         };
 
-        let work_dir = cwd.unwrap_or_else(|| {
-            std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"))
-        });
+        let work_dir =
+            cwd.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")));
 
         // Open PTY pair. openpty returns master + slave OwnedFds.
-        let pty_result = nix::pty::openpty(None, None)
-            .map_err(|e| format!("openpty failed: {}", e))?;
+        let pty_result =
+            nix::pty::openpty(None, None).map_err(|e| format!("openpty failed: {}", e))?;
 
         let master_fd = pty_result.master;
         let slave_fd = pty_result.slave;
@@ -225,7 +222,9 @@ impl PtyManager {
             });
         }
 
-        let child = cmd.spawn().map_err(|e| format!("Failed to spawn shell: {}", e))?;
+        let child = cmd
+            .spawn()
+            .map_err(|e| format!("Failed to spawn shell: {}", e))?;
 
         // Drop slave in parent — parent only ever touches master.
         drop(slave_fd);
@@ -331,7 +330,10 @@ impl PtyManager {
         };
         self.emit(workspace_id, &created_event).await;
 
-        info!("PTY session {} created for workspace {}", session_id, workspace_id);
+        info!(
+            "PTY session {} created for workspace {}",
+            session_id, workspace_id
+        );
         Ok(session_id)
     }
 
@@ -355,8 +357,7 @@ impl PtyManager {
         workspace_id: Uuid,
         mut reader: impl AsyncReadExt + Unpin,
         event_tx: broadcast::Sender<String>,
-        workspace_channels:
-            Option<Arc<Mutex<HashMap<Uuid, broadcast::Sender<String>>>>>,
+        workspace_channels: Option<WorkspaceChannels>,
     ) {
         let mut buf = vec![0u8; 4096];
         // UTF-8 codepoints are 1–4 bytes. A codepoint can straddle the read
@@ -398,13 +399,8 @@ impl PtyManager {
                         continue;
                     }
                     let event = AppEvent::TerminalOutput { session_id, data };
-                    Self::emit_via(
-                        &event_tx,
-                        workspace_channels.as_ref(),
-                        workspace_id,
-                        &event,
-                    )
-                    .await;
+                    Self::emit_via(&event_tx, workspace_channels.as_ref(), workspace_id, &event)
+                        .await;
                 }
             }
         }
@@ -468,8 +464,11 @@ impl PtyManager {
             // The stdout_reader task will exit when it sees EOF/error.
             // We do NOT call nix::libc::close() here — the Tokio Files own the fds.
             let _ = session.close_tx.send(()).await;
-            self.emit(workspace_id, &AppEvent::TerminalSessionClosed { session_id })
-                .await;
+            self.emit(
+                workspace_id,
+                &AppEvent::TerminalSessionClosed { session_id },
+            )
+            .await;
             Ok(())
         } else {
             Err(format!("Session {} not found", session_id))
@@ -605,14 +604,16 @@ mod tests {
         let manager = PtyManager::new(tx);
         let workspace_id = Uuid::new_v4();
 
-        let result = manager.create_session(
-            workspace_id,
-            "pane-1".to_string(),
-            Some("/bin/sh".to_string()),
-            Some(PathBuf::from("/tmp")),
-            None,
-            None,
-        ).await;
+        let result = manager
+            .create_session(
+                workspace_id,
+                "pane-1".to_string(),
+                Some("/bin/sh".to_string()),
+                Some(PathBuf::from("/tmp")),
+                None,
+                None,
+            )
+            .await;
 
         assert!(result.is_ok(), "create_session failed: {:?}", result.err());
         let session_id = result.unwrap();

--- a/crates/terminal-daemon/src/search_engine.rs
+++ b/crates/terminal-daemon/src/search_engine.rs
@@ -9,6 +9,7 @@ use tokio::process::Command;
 /// Search for `query` across files under `root` using grep.
 ///
 /// Falls back gracefully: `rg` if available, otherwise `grep -rn`.
+#[allow(clippy::too_many_arguments)]
 pub async fn search_files(
     root: &Path,
     query: &str,
@@ -30,9 +31,27 @@ pub async fn search_files(
         .unwrap_or(false);
 
     let output = if rg_available {
-        run_ripgrep(root, query, is_regex, case_sensitive, include_glob, exclude_glob, context_lines).await?
+        run_ripgrep(
+            root,
+            query,
+            is_regex,
+            case_sensitive,
+            include_glob,
+            exclude_glob,
+            context_lines,
+        )
+        .await?
     } else {
-        run_grep(root, query, is_regex, case_sensitive, include_glob, exclude_glob, context_lines).await?
+        run_grep(
+            root,
+            query,
+            is_regex,
+            case_sensitive,
+            include_glob,
+            exclude_glob,
+            context_lines,
+        )
+        .await?
     };
 
     let duration_ms = start.elapsed().as_millis() as u64;
@@ -141,10 +160,7 @@ async fn run_grep(
 ///   - `--`               — group separator
 ///
 /// We group context lines with the match that follows them.
-fn parse_grep_output(
-    raw: &str,
-    max_results: usize,
-) -> (Vec<SearchMatch>, usize, usize, bool) {
+fn parse_grep_output(raw: &str, max_results: usize) -> (Vec<SearchMatch>, usize, usize, bool) {
     // pending_context accumulates lines that precede the next match
     let mut pending_context: Vec<String> = Vec::new();
     // partial_match holds a match we have emitted but may still receive "after" context for

--- a/crates/terminal-daemon/src/server.rs
+++ b/crates/terminal-daemon/src/server.rs
@@ -32,83 +32,82 @@ pub fn build_router(state: Arc<DaemonState>) -> Router {
         .with_state(state)
 }
 
-async fn ws_handler(
-    ws: WebSocketUpgrade,
-    State(state): State<Arc<DaemonState>>,
-) -> Response {
+async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<DaemonState>>) -> Response {
     ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
 /// Serialize an event, returning a fallback error JSON on failure.
 fn event_json(event: &AppEvent) -> String {
     serde_json::to_string(event).unwrap_or_else(|e| {
-        format!(r#"{{"type":"Error","code":"SERIALIZATION","message":"{}"}}"#, e)
+        format!(
+            r#"{{"type":"Error","code":"SERIALIZATION","message":"{}"}}"#,
+            e
+        )
     })
 }
 
 async fn handle_socket(socket: WebSocket, state: Arc<DaemonState>) {
     let client_id = ClientId::new();
     let (mut sender, mut receiver) = socket.split();
-    info!("New WebSocket connection ({:?}), awaiting auth...", client_id);
+    info!(
+        "New WebSocket connection ({:?}), awaiting auth...",
+        client_id
+    );
 
     // Step 1: Auth handshake — first message must be Auth command
-    let authed = match tokio::time::timeout(
-        std::time::Duration::from_secs(10),
-        receiver.next(),
-    )
-    .await
-    {
-        Ok(Some(Ok(Message::Text(text)))) => {
-            info!("Auth message received: {}", &*text);
-            match serde_json::from_str::<AppCommand>(&*text) {
-                Ok(AppCommand::Auth { token }) if token == state.auth_token => {
-                    let resp = event_json(&AppEvent::AuthSuccess);
-                    let _ = sender.send(Message::Text(resp.into())).await;
-                    true
-                }
-                Ok(AppCommand::Auth { .. }) => {
-                    warn!("Auth failed: token mismatch");
-                    let resp = event_json(&AppEvent::AuthFailed {
-                        reason: "Invalid token".into(),
-                    });
-                    let _ = sender.send(Message::Text(resp.into())).await;
-                    false
-                }
-                Ok(other) => {
-                    warn!("Auth failed: expected Auth command, got {:?}", other);
-                    let resp = event_json(&AppEvent::AuthFailed {
-                        reason: "Expected Auth command".into(),
-                    });
-                    let _ = sender.send(Message::Text(resp.into())).await;
-                    false
-                }
-                Err(e) => {
-                    warn!("Auth failed: could not parse message: {}", e);
-                    let resp = event_json(&AppEvent::AuthFailed {
-                        reason: "Invalid token".into(),
-                    });
-                    let _ = sender.send(Message::Text(resp.into())).await;
-                    false
+    let authed =
+        match tokio::time::timeout(std::time::Duration::from_secs(10), receiver.next()).await {
+            Ok(Some(Ok(Message::Text(text)))) => {
+                info!("Auth message received: {}", &*text);
+                match serde_json::from_str::<AppCommand>(&text) {
+                    Ok(AppCommand::Auth { token }) if token == state.auth_token => {
+                        let resp = event_json(&AppEvent::AuthSuccess);
+                        let _ = sender.send(Message::Text(resp.into())).await;
+                        true
+                    }
+                    Ok(AppCommand::Auth { .. }) => {
+                        warn!("Auth failed: token mismatch");
+                        let resp = event_json(&AppEvent::AuthFailed {
+                            reason: "Invalid token".into(),
+                        });
+                        let _ = sender.send(Message::Text(resp.into())).await;
+                        false
+                    }
+                    Ok(other) => {
+                        warn!("Auth failed: expected Auth command, got {:?}", other);
+                        let resp = event_json(&AppEvent::AuthFailed {
+                            reason: "Expected Auth command".into(),
+                        });
+                        let _ = sender.send(Message::Text(resp.into())).await;
+                        false
+                    }
+                    Err(e) => {
+                        warn!("Auth failed: could not parse message: {}", e);
+                        let resp = event_json(&AppEvent::AuthFailed {
+                            reason: "Invalid token".into(),
+                        });
+                        let _ = sender.send(Message::Text(resp.into())).await;
+                        false
+                    }
                 }
             }
-        }
-        Ok(Some(Ok(other))) => {
-            warn!("Auth failed: expected Text message, got {:?}", other);
-            false
-        }
-        Ok(Some(Err(e))) => {
-            warn!("Auth failed: WebSocket error: {}", e);
-            false
-        }
-        Ok(None) => {
-            warn!("Auth failed: connection closed before auth");
-            false
-        }
-        Err(_) => {
-            warn!("Auth failed: 10s timeout");
-            false
-        }
-    };
+            Ok(Some(Ok(other))) => {
+                warn!("Auth failed: expected Text message, got {:?}", other);
+                false
+            }
+            Ok(Some(Err(e))) => {
+                warn!("Auth failed: WebSocket error: {}", e);
+                false
+            }
+            Ok(None) => {
+                warn!("Auth failed: connection closed before auth");
+                false
+            }
+            Err(_) => {
+                warn!("Auth failed: 10s timeout");
+                false
+            }
+        };
 
     if !authed {
         info!("Client failed auth, disconnecting");
@@ -187,30 +186,32 @@ async fn handle_socket(socket: WebSocket, state: Arc<DaemonState>) {
 
     while let Some(msg) = receiver.next().await {
         match msg {
-            Ok(Message::Text(text)) => {
-                match serde_json::from_str::<AppCommand>(&text) {
-                    Ok(AppCommand::Ping) => {
-                        let pong = event_json(&AppEvent::Pong);
-                        let mut s = sender.lock().await;
-                        let _ = s.send(Message::Text(pong.into())).await;
-                    }
-                    Ok(cmd) => {
-                        let cmd = cmd.sanitize();
-                        if let Err(e) = state.command_tx.send((client_id, cmd, response_tx.clone())).await {
-                            error!("Failed to forward command: {}", e);
-                        }
-                    }
-                    Err(e) => {
-                        warn!("Invalid command from client: {}", e);
-                        let err = event_json(&AppEvent::Error {
-                            code: "INVALID_COMMAND".into(),
-                            message: e.to_string(),
-                        });
-                        let mut s = sender.lock().await;
-                        let _ = s.send(Message::Text(err.into())).await;
+            Ok(Message::Text(text)) => match serde_json::from_str::<AppCommand>(&text) {
+                Ok(AppCommand::Ping) => {
+                    let pong = event_json(&AppEvent::Pong);
+                    let mut s = sender.lock().await;
+                    let _ = s.send(Message::Text(pong.into())).await;
+                }
+                Ok(cmd) => {
+                    let cmd = cmd.sanitize();
+                    if let Err(e) = state
+                        .command_tx
+                        .send((client_id, cmd, response_tx.clone()))
+                        .await
+                    {
+                        error!("Failed to forward command: {}", e);
                     }
                 }
-            }
+                Err(e) => {
+                    warn!("Invalid command from client: {}", e);
+                    let err = event_json(&AppEvent::Error {
+                        code: "INVALID_COMMAND".into(),
+                        message: e.to_string(),
+                    });
+                    let mut s = sender.lock().await;
+                    let _ = s.send(Message::Text(err.into())).await;
+                }
+            },
             Ok(Message::Pong(_)) => {
                 // Client responded to our ping — reset the timeout window.
                 *last_pong_at.lock().await = Instant::now();
@@ -267,18 +268,28 @@ mod tests {
         (port, token)
     }
 
-    async fn connect(port: u16) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    async fn connect(
+        port: u16,
+    ) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>
+    {
         let url = format!("ws://127.0.0.1:{}/ws", port);
         let (ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
         ws
     }
 
     fn auth_msg(token: &str) -> TungMessage {
-        let cmd = serde_json::to_string(&AppCommand::Auth { token: token.to_string() }).unwrap();
+        let cmd = serde_json::to_string(&AppCommand::Auth {
+            token: token.to_string(),
+        })
+        .unwrap();
         TungMessage::Text(cmd.into())
     }
 
-    async fn recv_text(ws: &mut tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>) -> String {
+    async fn recv_text(
+        ws: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    ) -> String {
         loop {
             match ws.next().await.unwrap().unwrap() {
                 TungMessage::Text(t) => return t.to_string(),
@@ -297,7 +308,11 @@ mod tests {
         let resp = recv_text(&mut ws).await;
 
         let event: serde_json::Value = serde_json::from_str(&resp).unwrap();
-        assert_eq!(event["type"], "AuthSuccess", "expected AuthSuccess, got: {}", resp);
+        assert_eq!(
+            event["type"], "AuthSuccess",
+            "expected AuthSuccess, got: {}",
+            resp
+        );
     }
 
     #[tokio::test]
@@ -309,7 +324,11 @@ mod tests {
         let resp = recv_text(&mut ws).await;
 
         let event: serde_json::Value = serde_json::from_str(&resp).unwrap();
-        assert_eq!(event["type"], "AuthFailed", "expected AuthFailed, got: {}", resp);
+        assert_eq!(
+            event["type"], "AuthFailed",
+            "expected AuthFailed, got: {}",
+            resp
+        );
     }
 
     #[tokio::test]
@@ -317,11 +336,17 @@ mod tests {
         let (port, _) = start_test_server().await;
         let mut ws = connect(port).await;
 
-        ws.send(TungMessage::Text("this is not json!!!".into())).await.unwrap();
+        ws.send(TungMessage::Text("this is not json!!!".into()))
+            .await
+            .unwrap();
         let resp = recv_text(&mut ws).await;
 
         let event: serde_json::Value = serde_json::from_str(&resp).unwrap();
-        assert_eq!(event["type"], "AuthFailed", "expected AuthFailed, got: {}", resp);
+        assert_eq!(
+            event["type"], "AuthFailed",
+            "expected AuthFailed, got: {}",
+            resp
+        );
     }
 
     #[tokio::test]
@@ -335,7 +360,11 @@ mod tests {
         let resp = recv_text(&mut ws).await;
 
         let event: serde_json::Value = serde_json::from_str(&resp).unwrap();
-        assert_eq!(event["type"], "AuthFailed", "expected AuthFailed, got: {}", resp);
+        assert_eq!(
+            event["type"], "AuthFailed",
+            "expected AuthFailed, got: {}",
+            resp
+        );
     }
 
     #[tokio::test]
@@ -350,7 +379,9 @@ mod tests {
         assert_eq!(event["type"], "AuthSuccess");
 
         // Send garbage post-auth
-        ws.send(TungMessage::Text("garbage command".into())).await.unwrap();
+        ws.send(TungMessage::Text("garbage command".into()))
+            .await
+            .unwrap();
         let resp = recv_text(&mut ws).await;
 
         let event: serde_json::Value = serde_json::from_str(&resp).unwrap();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,9 +125,10 @@ Starting a run:
 1. User clicks **Run** in `AiRunPane` → `runService.start(prompt, mode)` →
    `commandBus.dispatch({ type: 'StartRun', … })`.
 2. `useWebSocket.ts` sends the JSON payload over the open socket.
-3. Daemon `Dispatcher` receives, routes to run handler, spawns the Claude
-   subprocess inside a git worktree, streams stdout/stderr via
-   `broadcast::Sender<String>`.
+3. Daemon `Dispatcher` receives, routes to run handler, acquires a concurrency
+   guard keyed by the run's **actual working directory** (worktree path for git
+   runs, project root for non-git runs), then spawns the Claude subprocess and
+   streams stdout/stderr via `broadcast::Sender<String>`.
 4. Each event lands back as `AppEvent` (`RunStateChanged`, `RunOutput`,
    `RunCompleted`, …).
 5. `eventRouter.ts` dispatches the matching store action; panes re-render.

--- a/frontend/src/components/RunPanel.test.ts
+++ b/frontend/src/components/RunPanel.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { extractFileLineRefs } from './runPanelFileLinks';
+
+describe('extractFileLineRefs', () => {
+  it('extracts path:line and path:line:col references', () => {
+    const refs = extractFileLineRefs('error at src/main.rs:42 and ./foo/bar.ts:10:3');
+    expect(refs).toEqual([
+      expect.objectContaining({ path: 'src/main.rs', line: 42 }),
+      expect.objectContaining({ path: './foo/bar.ts', line: 10 }),
+    ]);
+  });
+
+  it('returns empty when no file reference is present', () => {
+    expect(extractFileLineRefs('all good, no stack trace')).toEqual([]);
+  });
+});

--- a/frontend/src/components/RunPanel.tsx
+++ b/frontend/src/components/RunPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import {
   Edit3,
   FileText,
@@ -13,6 +13,46 @@ import {
 } from 'lucide-react';
 import { useAppState } from '../context/AppContext';
 import type { ToolCall } from '../types/protocol';
+import { extractFileLineRefs } from './runPanelFileLinks';
+
+function openFileViewer(path: string): void {
+  window.dispatchEvent(new CustomEvent('open-file-viewer', { detail: { path } }));
+}
+
+function renderLineWithFileLinks(line: string): ReactNode {
+  const refs = extractFileLineRefs(line);
+  if (refs.length === 0) return line;
+
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  for (const ref of refs) {
+    if (ref.start > cursor) nodes.push(line.slice(cursor, ref.start));
+    nodes.push(
+      <button
+        key={`${ref.path}:${ref.line}:${ref.start}`}
+        onClick={() => openFileViewer(ref.path)}
+        style={{
+          border: 'none',
+          background: 'transparent',
+          padding: 0,
+          margin: 0,
+          color: 'var(--accent-primary)',
+          textDecoration: 'underline',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          fontSize: 'inherit',
+          lineHeight: 'inherit',
+        }}
+        title={`Open ${ref.path} (line ${ref.line})`}
+      >
+        {line.slice(ref.start, ref.end)}
+      </button>
+    );
+    cursor = ref.end;
+  }
+  if (cursor < line.length) nodes.push(line.slice(cursor));
+  return nodes;
+}
 
 /** Render a lucide icon for common Claude Code tool names. Rendered inline
  * (rather than assigning the component to a local `Icon`) so React's
@@ -281,7 +321,7 @@ export function RunPanel() {
               opacity: isStderr ? 0.95 : 1,
             }}
           >
-            {line}
+            {renderLineWithFileLinks(line)}
           </div>
         );
       })}

--- a/frontend/src/components/runPanelFileLinks.ts
+++ b/frontend/src/components/runPanelFileLinks.ts
@@ -1,0 +1,28 @@
+export interface FileLineRef {
+  path: string;
+  line: number;
+  start: number;
+  end: number;
+}
+
+// Matches common compiler/stack formats:
+//   src/main.rs:42
+//   ./src/main.ts:10:2
+const FILE_LINE_RE = /((?:\.{0,2}\/)?[A-Za-z0-9_./\\-]+\.[A-Za-z0-9_]+):(\d+)(?::\d+)?/g;
+
+export function extractFileLineRefs(line: string): FileLineRef[] {
+  const refs: FileLineRef[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = FILE_LINE_RE.exec(line)) !== null) {
+    const path = match[1];
+    const lineNumber = Number(match[2]);
+    if (!path || !Number.isFinite(lineNumber)) continue;
+    refs.push({
+      path,
+      line: lineNumber,
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+  return refs;
+}

--- a/frontend/src/core/services/runService.test.ts
+++ b/frontend/src/core/services/runService.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CommandBus } from '../commands/commandBus';
+import { RunService } from './runService';
+
+describe('RunService', () => {
+  it('startRun forwards autonomy explicitly in StartRun payload', () => {
+    const send = vi.fn();
+    const service = new RunService(new CommandBus(send));
+
+    service.startRun({
+      sessionId: 'session-1',
+      prompt: 'plan this work',
+      mode: 'Free',
+      autonomy: 'ReviewPlan',
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({
+      type: 'StartRun',
+      session_id: 'session-1',
+      prompt: 'plan this work',
+      mode: 'Free',
+      autonomy: 'ReviewPlan',
+      skip_dirty_check: undefined,
+    });
+  });
+
+  it('dispatches command payloads for cancel/diff/revert/merge helpers', () => {
+    const send = vi.fn();
+    const service = new RunService(new CommandBus(send));
+
+    service.cancelRun('run-1');
+    service.getDiff('run-1');
+    service.revertRun('run-1');
+    service.mergeRun('run-1');
+
+    expect(send).toHaveBeenNthCalledWith(1, {
+      type: 'CancelRun',
+      run_id: 'run-1',
+      reason: 'User cancelled',
+    });
+    expect(send).toHaveBeenNthCalledWith(2, { type: 'GetDiff', run_id: 'run-1' });
+    expect(send).toHaveBeenNthCalledWith(3, { type: 'RevertRun', run_id: 'run-1' });
+    expect(send).toHaveBeenNthCalledWith(4, { type: 'MergeRun', run_id: 'run-1' });
+  });
+});

--- a/frontend/src/core/services/runService.ts
+++ b/frontend/src/core/services/runService.ts
@@ -3,6 +3,14 @@
 import type { AutonomyLevel, RunMode } from '../../types/protocol';
 import type { CommandBus } from '../commands/commandBus';
 
+export interface RunServiceStartRunParams {
+  sessionId: string;
+  prompt: string;
+  mode: RunMode;
+  autonomy: AutonomyLevel;
+  skipDirtyCheck?: boolean;
+}
+
 export class RunService {
   private readonly bus: CommandBus;
 
@@ -10,7 +18,7 @@ export class RunService {
     this.bus = bus;
   }
 
-  startRun(params: { sessionId: string; prompt: string; mode: RunMode; autonomy?: AutonomyLevel; skipDirtyCheck?: boolean }): void {
+  startRun(params: RunServiceStartRunParams): void {
     this.bus.dispatch({
       type: 'StartRun',
       session_id: params.sessionId,

--- a/frontend/src/panes/ai-run/AiRunPane.tsx
+++ b/frontend/src/panes/ai-run/AiRunPane.tsx
@@ -1,12 +1,14 @@
 // AiRunPane — wraps the existing RunPanel + DecisionPanel as a pane (M2-04)
 
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Bot, Eye, AlertTriangle, X } from 'lucide-react';
 import { RunPanel } from '../../components/RunPanel';
 import { PostRunSummary } from '../../components/PostRunSummary';
 import { PromptComposer } from '../../components/PromptComposer';
 import { useSend } from '../../context/SendContext';
 import { useAppState, useAppDispatch } from '../../context/AppContext';
+import { CommandBus } from '../../core/commands/commandBus';
+import { RunService } from '../../core/services/runService';
 import type { PaneProps } from '../registry';
 import type { AutonomyLevel, RunMode, RunState } from '../../types/protocol';
 import { registerPane } from '../registry';
@@ -24,6 +26,7 @@ function isTerminalState(rs: RunState): boolean {
 
 export function AiRunPane({ pane: _pane, workspaceId: _workspaceId }: PaneProps) {
   const send = useSend();
+  const runService = useMemo(() => new RunService(new CommandBus(send)), [send]);
   const state = useAppState();
   const dispatch = useAppDispatch();
   const [prompt, setPrompt] = useState('');
@@ -42,9 +45,8 @@ export function AiRunPane({ pane: _pane, workspaceId: _workspaceId }: PaneProps)
     const p = (overridePrompt ?? prompt).trim();
     if (!state.activeSession || !p) return;
     lastPromptRef.current = p;
-    send({
-      type: 'StartRun',
-      session_id: state.activeSession,
+    runService.startRun({
+      sessionId: state.activeSession,
       prompt: p,
       mode: 'Free' as RunMode,
       autonomy: overrideAutonomy ?? autonomy,
@@ -53,12 +55,12 @@ export function AiRunPane({ pane: _pane, workspaceId: _workspaceId }: PaneProps)
   };
 
   const handleCancel = (runId: string) => {
-    send({ type: 'CancelRun', run_id: runId, reason: 'User cancelled' });
+    runService.cancelRun(runId, 'User cancelled');
   };
 
-  const handleGetDiff = (runId: string) => send({ type: 'GetDiff', run_id: runId });
-  const handleRevert = (runId: string) => send({ type: 'RevertRun', run_id: runId });
-  const handleMerge = (runId: string) => send({ type: 'MergeRun', run_id: runId });
+  const handleGetDiff = (runId: string) => runService.getDiff(runId);
+  const handleRevert = (runId: string) => runService.revertRun(runId);
+  const handleMerge = (runId: string) => runService.mergeRun(runId);
 
   const selectedRunObj = state.selectedRun ? state.runs.get(state.selectedRun) : undefined;
   const showPostRunSummary =

--- a/frontend/src/panes/terminal/TerminalPane.tsx
+++ b/frontend/src/panes/terminal/TerminalPane.tsx
@@ -274,7 +274,7 @@ export function TerminalPane({ pane, workspaceId, focused }: PaneProps) {
       clearTimeout(timer);
       window.removeEventListener('terminal-event', handler);
     };
-  }, [workspaceId, sessionState.tag]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [workspaceId, sessionState.tag]);
 
   // Step 3: Create a PTY session when component mounts — uses FIFO queue for reliable matching
   useEffect(() => {

--- a/frontend/src/state/workspace-store.test.ts
+++ b/frontend/src/state/workspace-store.test.ts
@@ -143,7 +143,8 @@ describe('workspaceReducer', () => {
   });
 
   it('SET_RUN_METRICS', () => {
-    const next = run(base(), {
+    const withActiveRun = run(base(), { type: 'SET_ACTIVE_RUN', runId: 'r1' });
+    const next = run(withActiveRun, {
       type: 'SET_RUN_METRICS',
       runId: 'r1',
       metrics: { num_turns: 1, cost_usd: 0.1, input_tokens: 10, output_tokens: 20 },


### PR DESCRIPTION
### Motivation

- Prevent repository-wide blocking by using the actual working directory (worktree path for git runs, project root otherwise) as the concurrency map key so parallel runs on different worktrees can proceed.
- Route PTY/terminal events to workspace-scoped channels and provide clearer, typed failures for git commands invoked without an active session.
- Improve frontend UX by making file:line references in run output clickable and add small API/service helpers to centralize run command dispatch.

### Description

- Change concurrency keying: introduce `concurrency_key_for_run`, acquire `ConcurrencyGuard` using the worktree path when present and project root otherwise, and surface a `WORKING_DIR_BUSY` error; refactor `do_start_run` to acquire guard after worktree resolution.
- PTY/terminal improvements: add `WorkspaceChannels` type alias, thread workspace-scoped `broadcast::Sender` into `PtyManager`, and route terminal events to the workspace channel with fallback to the global channel.
- Git dispatcher: add `require_project_root` helper and emit `AppEvent::GitOperationFailed` with operation/reason when no active session exists; add tests validating these typed failure responses.
- Persistence: harden `atomic_write` to fsync the directory and return failures instead of ignoring them, and add tests ensuring no leftover tmp files and that JSON is persisted non-empty.
- Miscellaneous core/daemon changes: derive `Default` for `AutonomyLevel`, small signature/format refactors (`detect_language` now takes `&Path`), normalize many `await`/formatting sites, improve preflight error messaging formatting, and ensure output paths are constructed/readably.
- Frontend: add `extractFileLineRefs` utility and clickable inline file links in `RunPanel`, introduce `RunService` to centralize run commands, wire it into `AiRunPane`, and add corresponding unit tests for the new utilities and service.
- Tests and small cleanup: add and update numerous unit tests across `terminal-daemon`, `terminal-core`, and frontend tests (Vitest); tidy logging/info messages and a few unsafe/IO call sites for clarity.

### Testing

- Ran Rust unit tests for the daemon and core crates via `cargo test` (including added `git_dispatcher`, `dispatcher`, `guards`, `persistence`, and `claude_runner` tests) and they passed.
- Ran frontend unit tests with `vitest` for the new `extractFileLineRefs`, `RunService` and `RunPanel` tests and they passed.
- Performed CI-style smoke checks for key flows (start run / create terminal session / list workspaces) via unit tests included in the change and observed no regressions in automated test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea968430c0833183d892ba6b92743f)